### PR TITLE
streamline dev testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,25 +74,50 @@ Neurodamus-models expects that you have modules available on your system for `py
 ---
 # Testing
 
-If you want to run only the base tests (after running `source setup --dev`) you can:
+First, make sure you have set up the development environment with test data:
+
+```bash
+source setup.sh --dev --data
+```
+
+This only needs to be done once. It will download a few hundreds of Mb of data and run a few short simulations.
+
+After that, the simplest way to run the full test suite is:
+
+```bash
+./run_tests.sh
+```
+
+You can also run subsets:
+
+```bash
+./run_tests.sh unit   # only unit tests
+./run_tests.sh mpi    # only MPI tests
+```
+
+If you need to re-run setup before testing:
+
+```bash
+./run_tests.sh --setup
+```
+
+Alternatively, you can run the tests manually:
+
+```bash
+python -m pytest tests/unit/ -v --forked
+mpirun -n 2 python -m pytest tests/unit-mpi/test_write_weights.py --with-mpi -v
+mpirun -n 2 python -m pytest tests/unit-mpi/test_h5py_MPI.py --with-mpi -v
+mpirun -n 2 python -m pytest tests/unit-mpi/test_get_positions.py --with-mpi -v
+```
+
+If you want to run only the base tests (without downloading data), after `source setup.sh --dev`:
 
 ```bash
 mpirun -n 2 pytest -v tests/unit-mpi --with-mpi
 pytest -v -m "not skip_in_ci" tests/unit
 ```
 
-If you want to run all the tests you need to collect various files from [Zenodo](https://doi.org/10.5281/zenodo.10927050). The simplest way is to let setup do the job:
-
-```bash
-setup.sh --dev --data
-```
-
-This will download a few hundreds of Mb of data and run a few short simulations. After that you have access to the full suite of tests:
-
-```bash
-pytest tests/unit
-mpirun -n 2 pytest -v tests/unit-mpi --with-mpi
-```
+This is also what runs in CI, where we avoid downloading the full test data to keep pipelines fast and lightweight.
 
 
 ### Steps to produce electrode files

--- a/bluerecording/circuit.py
+++ b/bluerecording/circuit.py
@@ -5,10 +5,56 @@ Provides the entry point for loading a circuit model and extracting
 the discretization info (node IDs, compartment structure, morphology access)
 needed by both get_positions and write_weights.
 """
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
 import bluepysnap as bp
 import libsonata
 import neurodamus
 import numpy as np
+
+
+@contextmanager
+def _prepare_simconfig(path_to_simconfig: str):
+    """Context manager yielding a simulation config path for circuit initialization.
+
+    If the config contains ``run.electrodes_file``, a temporary copy is written
+    next to the original (reports removed, tstop set to dt) so that neurodamus
+    builds the circuit without trying to load electrode weights. The temporary
+    file is always removed on exit, even if neurodamus raises.
+
+    Otherwise the original path is yielded unchanged.
+    """
+    config_path = Path(path_to_simconfig).resolve()
+
+    with open(config_path, encoding="utf-8") as f:
+        config = json.load(f)
+
+    if "electrodes_file" not in config.get("run", {}):
+        yield str(config_path)
+        return
+
+    del config["run"]["electrodes_file"]
+    config.pop("reports", None)
+    config["run"]["tstop"] = config["run"].get("dt", 0.025)
+
+    stem = config_path.stem
+    suffix = config_path.suffix
+    base_path = config_path.parent / f".{stem}_bluerecording_base{suffix}"
+
+    if base_path.exists():
+        raise FileExistsError(
+            f"Temporary config file already exists: {base_path}. "
+            "Remove it manually if it is not needed."
+        )
+
+    try:
+        with open(base_path, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2)
+        yield str(base_path)
+    finally:
+        base_path.unlink(missing_ok=True)
 
 
 def init_circuit(path_to_simconfig: str):
@@ -26,13 +72,14 @@ def init_circuit(path_to_simconfig: str):
             resolution.
         population_name: Name of the SONATA node population.
     """
-    nd = neurodamus.Neurodamus(
-        path_to_simconfig,
-        disable_reports=True,
-        direct_mode=True,
-        build_model=True,
-        enable_coord_mapping=True,
-    )
+    with _prepare_simconfig(path_to_simconfig) as effective_config:
+        nd = neurodamus.Neurodamus(
+            effective_config,
+            disable_reports=True,
+            direct_mode=True,
+            build_model=True,
+            enable_coord_mapping=True,
+        )
     assert len(nd.circuits.node_managers) == 1, (
         "Multiple or no node managers are not allowed for the moment"
     )

--- a/bluerecording/circuit.py
+++ b/bluerecording/circuit.py
@@ -5,56 +5,10 @@ Provides the entry point for loading a circuit model and extracting
 the discretization info (node IDs, compartment structure, morphology access)
 needed by both get_positions and write_weights.
 """
-import json
-from contextlib import contextmanager
-from pathlib import Path
-
 import bluepysnap as bp
 import libsonata
 import neurodamus
 import numpy as np
-
-
-@contextmanager
-def _prepare_simconfig(path_to_simconfig: str):
-    """Context manager yielding a simulation config path for circuit initialization.
-
-    If the config contains ``run.electrodes_file``, a temporary copy is written
-    next to the original (reports removed, tstop set to dt) so that neurodamus
-    builds the circuit without trying to load electrode weights. The temporary
-    file is always removed on exit, even if neurodamus raises.
-
-    Otherwise the original path is yielded unchanged.
-    """
-    config_path = Path(path_to_simconfig).resolve()
-
-    with open(config_path, encoding="utf-8") as f:
-        config = json.load(f)
-
-    if "electrodes_file" not in config.get("run", {}):
-        yield str(config_path)
-        return
-
-    del config["run"]["electrodes_file"]
-    config.pop("reports", None)
-    config["run"]["tstop"] = config["run"].get("dt", 0.025)
-
-    stem = config_path.stem
-    suffix = config_path.suffix
-    base_path = config_path.parent / f".{stem}_bluerecording_base{suffix}"
-
-    if base_path.exists():
-        raise FileExistsError(
-            f"Temporary config file already exists: {base_path}. "
-            "Remove it manually if it is not needed."
-        )
-
-    try:
-        with open(base_path, "w", encoding="utf-8") as f:
-            json.dump(config, f, indent=2)
-        yield str(base_path)
-    finally:
-        base_path.unlink(missing_ok=True)
 
 
 def init_circuit(path_to_simconfig: str):
@@ -72,14 +26,15 @@ def init_circuit(path_to_simconfig: str):
             resolution.
         population_name: Name of the SONATA node population.
     """
-    with _prepare_simconfig(path_to_simconfig) as effective_config:
-        nd = neurodamus.Neurodamus(
-            effective_config,
-            disable_reports=True,
-            direct_mode=True,
-            build_model=True,
-            enable_coord_mapping=True,
-        )
+    nd = neurodamus.Neurodamus(
+        path_to_simconfig,
+        disable_reports=True,
+        direct_mode=True,
+        build_model=True,
+        enable_coord_mapping=True,
+        keep_build=False,
+        simulator="NEURON",
+    )
     assert len(nd.circuits.node_managers) == 1, (
         "Multiple or no node managers are not allowed for the moment"
     )

--- a/examples/circuitTest/test/simulation/simulation_config.json
+++ b/examples/circuitTest/test/simulation/simulation_config.json
@@ -6,7 +6,7 @@
     "tstop": 100,
     "electrodes_file": "../electrodeFile/coeffs.h5"
   },
-  "network": "../../data/simulation/configuration/circuit_config.json",
+  "network": "../../data/configuration/circuit_config.json",
   "node_sets_file": "user_node_sets.json",
   "node_set": "hex_O1_L4_100",
   "target_simulator": "CORENEURON",

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# run_tests.sh — Run all tests (unit + MPI) in the dev environment.
+#
+# Assumes that 'source setup.sh --dev --data' has been called at least once
+# and the virtual environment is active (i.e. you are in the venv).
+#
+# Usage:
+#   ./run_tests.sh              # run all tests
+#   ./run_tests.sh unit         # run only unit tests
+#   ./run_tests.sh mpi          # run only MPI tests
+#   ./run_tests.sh --setup      # re-run setup before testing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+RUN_SETUP=0
+SUITE="all"
+
+for arg in "$@"; do
+    case $arg in
+        --setup)  RUN_SETUP=1 ;;
+        unit)     SUITE="unit" ;;
+        mpi)      SUITE="mpi" ;;
+        all)      SUITE="all" ;;
+        -h|--help)
+            echo "Usage: ./run_tests.sh [--setup] [unit|mpi|all]"
+            echo ""
+            echo "  --setup   Source setup.sh --dev --data before running tests"
+            echo "  unit      Run only unit tests"
+            echo "  mpi       Run only MPI tests"
+            echo "  all       Run all tests (default)"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg (try --help)"
+            exit 1
+            ;;
+    esac
+done
+
+# -------------------------
+# Environment setup
+# -------------------------
+if [[ "$RUN_SETUP" -eq 1 ]]; then
+    echo "=== Running setup.sh --dev --data ==="
+    source setup.sh --dev --data
+elif [[ -d "venv" ]]; then
+    source venv/bin/activate
+else
+    echo "Error: No venv found. Run with --setup first, or 'source setup.sh --dev --data' manually."
+    exit 1
+fi
+
+FAILED=0
+
+echo ""
+echo "Note: This script assumes 'source setup.sh --dev --data' was called at least once"
+echo "      and the virtual environment is active."
+echo ""
+
+# -------------------------
+# Unit tests
+# -------------------------
+if [[ "$SUITE" == "all" || "$SUITE" == "unit" ]]; then
+    echo ""
+    echo "========================================="
+    echo "  Running unit tests"
+    echo "========================================="
+    python -m pytest tests/unit/ -v --forked || FAILED=1
+fi
+
+# -------------------------
+# MPI tests
+# -------------------------
+if [[ "$SUITE" == "all" || "$SUITE" == "mpi" ]]; then
+    echo ""
+    echo "========================================="
+    echo "  Running MPI tests"
+    echo "========================================="
+    for test_file in tests/unit-mpi/test_write_weights.py \
+                     tests/unit-mpi/test_h5py_MPI.py \
+                     tests/unit-mpi/test_get_positions.py; do
+        echo ""
+        echo "--- mpirun -n 2: $test_file ---"
+        mpirun -n 2 python -m pytest "$test_file" --with-mpi -v || FAILED=1
+    done
+fi
+
+# -------------------------
+# Summary
+# -------------------------
+echo ""
+if [[ "$FAILED" -eq 1 ]]; then
+    echo "⚠  Some tests failed."
+    exit 1
+else
+    echo "✅ All tests passed."
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -121,7 +121,8 @@ else
     
     pip install --no-binary=mpi4py mpi4py
     pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
-    pip install neurodamus
+
+    pip install git+https://github.com/openbraininstitute/neurodamus.git@main
 fi
 
 # -------------------------


### PR DESCRIPTION
## Context

Fix #27 

## Scope

- Add `run_tests.sh` script to run all tests (unit + MPI) in a single command
- Support running test subsets via `./run_tests.sh unit` or `./run_tests.sh mpi`
- Update README Testing section to document the new test runner
- Clarify that CI runs only the base tests to avoid downloading large datasets
