### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           key: venv-${{ runner.os }}-py311-${{ hashFiles('setup.sh', 'pyproject.toml') }}
 
       - name: Run setup.sh
-        run: ./setup.sh --dev --no-system
+        run: ./setup.sh --dev --no-system --quick
 
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ source setup.sh --dev
 
 If you want to skip the system packages installation append `--no-system` to the previous lines.
 
+Use `--quick` to skip building NEURON, libsonatareport, and neurodamus-models from source (useful for CI or when you only need the Python package):
+
+```bash
+source setup.sh --dev --quick
+```
+
+Use `--no-cache` to wipe the virtual environment and all build artifacts before reinstalling from scratch (downloaded data is preserved):
+
+```bash
+source setup.sh --dev --no-cache
+```
+
 Finally, if you want to run the full testing suite you need `--data`. See the [Testing](#testing) section for details.
 
 
@@ -48,8 +60,10 @@ The initial input data of `BlueRecording` includes a [compartment report](https:
 On the first run, the script will:
 1. Create a Python virtual environment with MPI-enabled `h5py` and `mpi4py`
 2. Clone and build `libsonatareport`
-3. Clone and build `neurodamus-models` (neocortex)
-4. Install the `bluerecording` package
+3. Clone and build NEURON from source (with `libsonatareport` support)
+4. Install `neurodamus` from source
+5. Clone and build `neurodamus-models` (neocortex)
+6. Install the `bluerecording` package
 
 In subsequent sessions, running `source setup.sh` again will simply activate the existing environment.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ pytest -v -m "not skip_in_ci" tests/unit
 
 This is also what runs in CI, where we avoid downloading the full test data to keep pipelines fast and lightweight.
 
+> **Note:** If you installed with the `--quick` flag (i.e. `source setup.sh --dev --quick`), NEURON, neurodamus, and libsonatareport are not available. In that case only the non-MPI unit tests can run:
+> ```bash
+> pytest -v -m "not skip_in_ci" tests/unit
+> ```
+> The MPI tests and any test that requires neurodamus will be skipped or fail.
+
 To run only the slow, data-intensive tests (e.g., single cell and 100-cell integration tests):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ source setup.sh --dev
 
 If you want to skip the system packages installation append `--no-system` to the previous lines.
 
-Use `--quick` to skip building NEURON, libsonatareport, and neurodamus-models from source (useful for CI or when you only need the Python package):
+Use `--quick` to skip building NEURON, libsonatareport, neurodamus, and neurodamus-models from source (useful for CI or when you only need the Python package):
 
 ```bash
 source setup.sh --dev --quick
@@ -115,7 +115,7 @@ pytest -v -m "not skip_in_ci" tests/unit
 
 This is also what runs in CI, where we avoid downloading the full test data to keep pipelines fast and lightweight.
 
-> **Note:** If you installed with the `--quick` flag (i.e. `source setup.sh --dev --quick`), NEURON, neurodamus, and libsonatareport are not available. In that case only the non-MPI unit tests can run:
+> **Note:** If you installed with the `--quick` flag (i.e. `source setup.sh --dev --quick`), NEURON, neurodamus, libsonatareport, and neurodamus-models are not available. In that case only the non-MPI unit tests can run:
 > ```bash
 > pytest -v -m "not skip_in_ci" tests/unit
 > ```

--- a/bluerecording/circuit.py
+++ b/bluerecording/circuit.py
@@ -7,7 +7,6 @@ needed by both get_positions and write_weights.
 """
 import bluepysnap as bp
 import libsonata
-import neurodamus
 import numpy as np
 
 
@@ -26,6 +25,10 @@ def init_circuit(path_to_simconfig: str):
             resolution.
         population_name: Name of the SONATA node population.
     """
+    # Lazy import: neurodamus pulls in NEURON, which is not available
+    # in lightweight installs (e.g. CI with --quick).
+    import neurodamus
+
     nd = neurodamus.Neurodamus(
         path_to_simconfig,
         disable_reports=True,

--- a/examples/single_cell_l5_tpc/README.md
+++ b/examples/single_cell_l5_tpc/README.md
@@ -34,7 +34,7 @@ bluerecording write_weights examples/single_cell_l5_tpc/simulation_config_near.j
 
 ## Running the Simulation
 
-To run the simulation you need NEURON compiled with [libsonatareport](https://github.com/openbraininstitute/libsonatareport) support. The NEURON installed by `setup.sh` is the PyPI wheel, which does not include libsonatareport.
+To run the simulation you need NEURON compiled with [libsonatareport](https://github.com/openbraininstitute/libsonatareport) support. The `setup.sh` script builds NEURON from source with this support.
 
 Once your environment is ready, run:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluerecording"
-version = "0.3.0"
+dynamic = ["version"]
 description = "A tool for calculating extracellular recording lead fields"
 requires-python = ">=3.10"
 dependencies = [
@@ -27,10 +27,19 @@ all = [
 ]
 
 [build-system]
-requires = ["setuptools>=64", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
-[tool.setuptools]
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
+[tool.hatch.build.targets.sdist]
+only-include = ["bluerecording"]
+
+[tool.hatch.build.targets.wheel]
 packages = ["bluerecording"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluerecording"
-version = "0.2.1"
+version = "0.3.0"
 description = "A tool for calculating extracellular recording lead fields"
 requires-python = ">=3.10"
 dependencies = [

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 # -------------------------
 # Pinned versions (edit here to update)
 # -------------------------
-NEURON_COMMIT="0d990513b"
+NEURON_COMMIT="9.0.1"
 
 if command -v deactivate &> /dev/null; then
     deactivate

--- a/setup.sh
+++ b/setup.sh
@@ -170,74 +170,74 @@ fi
 # -------------------------
 if [[ $QUICK -eq 0 ]]; then
 
-# -------------------------
-# Install libsonatareport
-# -------------------------
-if [ ! -d "libsonatareport" ]; then
-    git clone https://github.com/openbraininstitute/libsonatareport.git --recursive --depth=1
-    cmake -B libsonatareport/build -S libsonatareport \
-    -DCMAKE_INSTALL_PREFIX=$SONATAREPORT_DIR -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON -GNinja
+    # -------------------------
+    # Install libsonatareport
+    # -------------------------
+    if [ ! -d "libsonatareport" ]; then
+        git clone https://github.com/openbraininstitute/libsonatareport.git --recursive --depth=1
+        cmake -B libsonatareport/build -S libsonatareport \
+            -DCMAKE_INSTALL_PREFIX=$SONATAREPORT_DIR -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON -GNinja
 
-    cmake --build libsonatareport/build
-    cmake --install libsonatareport/build
-fi
-
-# -------------------------
-# Install NEURON from source (with libsonatareport support)
-# -------------------------
-if [ ! -d "nrn" ]; then
-    echo "=== Building NEURON from source ==="
-    git clone --branch=master https://github.com/neuronsimulator/nrn.git
-    cd nrn && git checkout $NEURON_COMMIT && cd ..
-    pip install --upgrade pip -r nrn/nrn_requirements.txt
-
-    if [[ "$OS" == "Darwin" ]]; then
-        NRN_C_COMPILER=gcc
-        NRN_CXX_COMPILER=g++
-    else
-        NRN_C_COMPILER=gcc
-        NRN_CXX_COMPILER=g++
+        cmake --build libsonatareport/build
+        cmake --install libsonatareport/build
     fi
 
-    cmake -B nrn/build -S nrn -G Ninja \
-        -DPYTHON_EXECUTABLE=$(which python) \
-        -DCMAKE_INSTALL_PREFIX=$(pwd)/nrn/build/install \
-        -DNRN_ENABLE_MPI=ON \
-        -DNRN_ENABLE_INTERVIEWS=OFF \
-        -DNRN_ENABLE_CORENEURON=ON \
-        -DCMAKE_C_COMPILER=$NRN_C_COMPILER \
-        -DCMAKE_CXX_COMPILER=$NRN_CXX_COMPILER \
-        -DCORENRN_ENABLE_REPORTING=ON \
-        -DCMAKE_PREFIX_PATH=$SONATAREPORT_DIR
+    # -------------------------
+    # Install NEURON from source (with libsonatareport support)
+    # -------------------------
+    if [ ! -d "nrn" ]; then
+        echo "=== Building NEURON from source ==="
+        git clone --branch=master https://github.com/neuronsimulator/nrn.git
+        cd nrn && git checkout $NEURON_COMMIT && cd ..
+        pip install --upgrade pip -r nrn/nrn_requirements.txt
 
-    cmake --build nrn/build --parallel
-    cmake --build nrn/build --target install
-fi
+        if [[ "$OS" == "Darwin" ]]; then
+            NRN_C_COMPILER=gcc
+            NRN_CXX_COMPILER=g++
+        else
+            NRN_C_COMPILER=gcc
+            NRN_CXX_COMPILER=g++
+        fi
 
-# -------------------------
-# Install neurodamus
-# -------------------------
-pip install git+https://github.com/openbraininstitute/neurodamus.git@main
+        cmake -B nrn/build -S nrn -G Ninja \
+            -DPYTHON_EXECUTABLE=$(which python) \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/nrn/build/install \
+            -DNRN_ENABLE_MPI=ON \
+            -DNRN_ENABLE_INTERVIEWS=OFF \
+            -DNRN_ENABLE_CORENEURON=ON \
+            -DCMAKE_C_COMPILER=$NRN_C_COMPILER \
+            -DCMAKE_CXX_COMPILER=$NRN_CXX_COMPILER \
+            -DCORENRN_ENABLE_REPORTING=ON \
+            -DCMAKE_PREFIX_PATH=$SONATAREPORT_DIR
 
-# -------------------------
-# Install neurodamus-models
-# -------------------------
-if [ ! -d "neurodamus-models" ]; then
-  git clone https://github.com/openbraininstitute/neurodamus-models.git
-  NEURODAMUS_PYTHON=$(python -c "import neurodamus; from pathlib import Path; print(Path(neurodamus.__file__).parent / 'data')")
+        cmake --build nrn/build --parallel
+        cmake --build nrn/build --target install
+    fi
 
-  cmake -B neurodamus-models/build -S neurodamus-models/ \
-      -DPython_EXECUTABLE=$(which python) \
-      -DCMAKE_INSTALL_PREFIX=$NEURODAMUS_NEOCORTEX_ROOT \
-      -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
-      -DCMAKE_PREFIX_PATH=$SONATAREPORT_DIR \
-      -DNEURODAMUS_CORE_DIR=${NEURODAMUS_PYTHON} \
-      -DNEURODAMUS_MECHANISMS=neocortex \
-      -DNEURODAMUS_NCX_V5=ON
+    # -------------------------
+    # Install neurodamus
+    # -------------------------
+    pip install git+https://github.com/openbraininstitute/neurodamus.git@main
 
-  cmake --build neurodamus-models/build
-  cmake --install neurodamus-models/build
-fi
+    # -------------------------
+    # Install neurodamus-models
+    # -------------------------
+    if [ ! -d "neurodamus-models" ]; then
+        git clone https://github.com/openbraininstitute/neurodamus-models.git
+        NEURODAMUS_PYTHON=$(python -c "import neurodamus; from pathlib import Path; print(Path(neurodamus.__file__).parent / 'data')")
+
+        cmake -B neurodamus-models/build -S neurodamus-models/ \
+            -DPython_EXECUTABLE=$(which python) \
+            -DCMAKE_INSTALL_PREFIX=$NEURODAMUS_NEOCORTEX_ROOT \
+            -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
+            -DCMAKE_PREFIX_PATH=$SONATAREPORT_DIR \
+            -DNEURODAMUS_CORE_DIR=${NEURODAMUS_PYTHON} \
+            -DNEURODAMUS_MECHANISMS=neocortex \
+            -DNEURODAMUS_NCX_V5=ON
+
+        cmake --build neurodamus-models/build
+        cmake --install neurodamus-models/build
+    fi
 
 fi # end --quick guard
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 # setup.sh — Full MPI-enabled Python environment setup
 
+# -------------------------
+# Pinned versions (edit here to update)
+# -------------------------
+NEURON_COMMIT="0d990513b"
+
+if command -v deactivate &> /dev/null; then
+    deactivate
+fi
+
 INSTALL_MODE="normal"
 SKIP_SYSTEM=0
 DOWNLOAD_DATA=0
+NO_CACHE=0
+QUICK=0
 
 # -------------------------
 # Parse arguments (with --help)
@@ -13,6 +24,8 @@ for arg in "$@"; do
         --dev) INSTALL_MODE="dev" ;;
         --no-system) SKIP_SYSTEM=1 ;;
         --data) DOWNLOAD_DATA=1 ;;
+        --no-cache) NO_CACHE=1 ;;
+        --quick) QUICK=1 ;;
         --help|-h)
             echo "Usage: source setup.sh [OPTIONS]"
             echo ""
@@ -20,6 +33,8 @@ for arg in "$@"; do
             echo "  --dev         Install development version (includes -e pip install)"
             echo "  --no-system   Skip system package installation"
             echo "  --data        Download and unpack datasets"
+            echo "  --no-cache    Remove venv, cloned repos, and build artifacts (keeps data)"
+            echo "  --quick       Skip NEURON, libsonatareport, and neurodamus-models builds"
             echo "  --help, -h    Show this help message"
             return 0 2>/dev/null || exit 0
             ;;
@@ -31,6 +46,31 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+# -------------------------
+# No-cache mode
+# -------------------------
+if [[ $NO_CACHE -eq 1 ]]; then
+    echo "This will remove:"
+    echo "  - venv/"
+    echo "  - nrn/"
+    echo "  - libsonatareport/"
+    echo "  - neurodamus-models/"
+    echo "  - bluerecording.egg-info/"
+    echo "  - build/"
+    echo ""
+    echo "Downloaded data will NOT be removed."
+    echo ""
+    printf "Are you sure? [y/N] "
+    read -r confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+        rm -rf venv nrn libsonatareport neurodamus-models bluerecording.egg-info build
+        echo "=== Clean complete ==="
+    else
+        echo "=== Clean cancelled ==="
+        return 0 2>/dev/null || exit 0
+    fi
+fi
 
 echo "=== Install mode: $INSTALL_MODE ==="
 echo "=== Skip system installation: $SKIP_SYSTEM ==="
@@ -75,6 +115,7 @@ export SONATAREPORT_DIR="$(pwd)/libsonatareport/build/install"
 export NEURODAMUS_NEOCORTEX_ROOT="$(pwd)/neurodamus-models/build/install"
 export HOC_LIBRARY_PATH="$NEURODAMUS_NEOCORTEX_ROOT/share/neurodamus_neocortex/hoc"
 export PATH=$(pwd)/nrn/build/install/bin:$PATH
+export PYTHONPATH=$(pwd)/nrn/build/install/lib/python:$PYTHONPATH
 export PATH=$NEURODAMUS_NEOCORTEX_ROOT/bin:$PATH
 
 if [[ "$OS" == "Darwin" ]]; then
@@ -103,7 +144,7 @@ else
     python3 -m venv venv
     source venv/bin/activate
 
-    pip install --upgrade pip setuptools wheel cython numpy NEURON-nightly
+    pip install --upgrade pip setuptools wheel cython numpy
 
     echo "=== Configuring MPI build environment ==="
     export CC=$(which mpicc)
@@ -118,12 +159,16 @@ else
     fi
 
     echo "=== Installing base dependencies ==="
-    
+
     pip install --no-binary=mpi4py mpi4py
     pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
-
-    pip install git+https://github.com/openbraininstitute/neurodamus.git@main
 fi
+
+# -------------------------
+# Install libsonatareport, NEURON, neurodamus, neurodamus-models
+# (skipped with --quick)
+# -------------------------
+if [[ $QUICK -eq 0 ]]; then
 
 # -------------------------
 # Install libsonatareport
@@ -136,6 +181,43 @@ if [ ! -d "libsonatareport" ]; then
     cmake --build libsonatareport/build
     cmake --install libsonatareport/build
 fi
+
+# -------------------------
+# Install NEURON from source (with libsonatareport support)
+# -------------------------
+if [ ! -d "nrn" ]; then
+    echo "=== Building NEURON from source ==="
+    git clone --branch=master https://github.com/neuronsimulator/nrn.git
+    cd nrn && git checkout $NEURON_COMMIT && cd ..
+    pip install --upgrade pip -r nrn/nrn_requirements.txt
+
+    if [[ "$OS" == "Darwin" ]]; then
+        NRN_C_COMPILER=gcc
+        NRN_CXX_COMPILER=g++
+    else
+        NRN_C_COMPILER=gcc
+        NRN_CXX_COMPILER=g++
+    fi
+
+    cmake -B nrn/build -S nrn -G Ninja \
+        -DPYTHON_EXECUTABLE=$(which python) \
+        -DCMAKE_INSTALL_PREFIX=$(pwd)/nrn/build/install \
+        -DNRN_ENABLE_MPI=ON \
+        -DNRN_ENABLE_INTERVIEWS=OFF \
+        -DNRN_ENABLE_CORENEURON=ON \
+        -DCMAKE_C_COMPILER=$NRN_C_COMPILER \
+        -DCMAKE_CXX_COMPILER=$NRN_CXX_COMPILER \
+        -DCORENRN_ENABLE_REPORTING=ON \
+        -DCMAKE_PREFIX_PATH=$SONATAREPORT_DIR
+
+    cmake --build nrn/build --parallel
+    cmake --build nrn/build --target install
+fi
+
+# -------------------------
+# Install neurodamus
+# -------------------------
+pip install git+https://github.com/openbraininstitute/neurodamus.git@main
 
 # -------------------------
 # Install neurodamus-models
@@ -156,6 +238,8 @@ if [ ! -d "neurodamus-models" ]; then
   cmake --build neurodamus-models/build
   cmake --install neurodamus-models/build
 fi
+
+fi # end --quick guard
 
 
 # -------------------------

--- a/setup.sh
+++ b/setup.sh
@@ -34,7 +34,7 @@ for arg in "$@"; do
             echo "  --no-system   Skip system package installation"
             echo "  --data        Download and unpack datasets"
             echo "  --no-cache    Remove venv, cloned repos, and build artifacts (keeps data)"
-            echo "  --quick       Skip NEURON, libsonatareport, and neurodamus-models builds"
+            echo "  --quick       Skip NEURON, libsonatareport, neurodamus, and neurodamus-models builds"
             echo "  --help, -h    Show this help message"
             return 0 2>/dev/null || exit 0
             ;;


### PR DESCRIPTION
## Context

Bump version to `0.3.0` to mark the first OBI-era release.

This goes on top of #31, which brings the codebase to a stable point after the BBP to OBI migration. Key changes since `v0.2.1`:

- Neurodamus integration for discretization and roto-translation via `ndam`. Greatly streamlined weights creation
- Consolidated weight computation into a single `weights` module
- MPI-parallel test coverage with CI
- Standardized examples with a ready-to-run `single_cell_l5_tpc` setup
- PEP 8 naming, isolated test fixtures, and updated documentation
- `setup.sh` now builds `NEURON` from source with `libsonatareport` support (pinned commit), enabling end-to-end simulation out of the box
- Added `--no-cache` flag to setup.sh for a clean rebuild of the entire environment (preserves downloaded data)
- Added `--quick` flag to setup.sh to skip `NEURON`/`libsonatareport`/`neurodamus-models builds` (used by CI)
Lazy import of neurodamus in `circuit.py` so lightweight installs don't break at import time. It also skips `neurodamus` install (clarified in docs)
- Switched to `hatch-vcs` for dynamic versioning from git tags
- Bumped NEURON pin to `9.0.1`