### PR TITLE
update `positions`

### DIFF
--- a/bluerecording/positions.py
+++ b/bluerecording/positions.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import json
 import os
-import warnings
 
 import libsonata
 import numpy as np
@@ -12,15 +11,9 @@ from mpi4py import MPI
 from pathlib import Path
 from scipy.interpolate import interp1d
 
-from .utils import *
-from .circuit import init_circuit
+from .utils import get_circuit_path
 
 rank = MPI.COMM_WORLD.Get_rank()
-
-
-warnings.filterwarnings('error', '', RuntimeWarning)
-'''
-'''
 
 
 class PositionedMorphology:

--- a/bluerecording/positions.py
+++ b/bluerecording/positions.py
@@ -528,7 +528,14 @@ def _find_morph_file(morph_name: str, morph_dir: str) -> str:
     )
 
 
-def get_positions(node_manager, ids, cols, population, path_to_simconfig, replace_axons=True):
+def get_positions(
+    node_manager,
+    ids: np.ndarray,
+    cols: np.ndarray,
+    population: libsonata.NodePopulation,
+    path_to_simconfig: str,
+    replace_axons: bool = True,
+) -> tuple[pd.DataFrame, np.ndarray, np.ndarray]:
     """Compute segment boundary positions for all cells on this rank.
 
     Pure computation — no file I/O. Returns the positions DataFrame,
@@ -596,7 +603,7 @@ def get_positions(node_manager, ids, cols, population, path_to_simconfig, replac
 
 
 
-def save_positions(positions_df, path_to_positions_folder):
+def save_positions(positions_df: pd.DataFrame, path_to_positions_folder: str | Path) -> None:
     """Write positions DataFrame to a pickle file for this MPI rank.
 
     Args:

--- a/bluerecording/positions.py
+++ b/bluerecording/positions.py
@@ -420,46 +420,59 @@ def get_new_index(cols: np.ndarray) -> pd.MultiIndex:
 
     return pd.MultiIndex.from_tuples(new_idx, names=["id", "section"])
 
-def get_cell_positions(m, center, cols, gid, replace_axons):
+def _get_cell_positions(
+    m: PositionedMorphology,
+    center: np.ndarray,
+    cols: np.ndarray,
+    gid: int,
+    replace_axons: bool,
+) -> np.ndarray:
     """Compute the 3D segment boundary positions for a single cell.
 
-    Returns a (3, N) array where each column is the x/y/z position of a segment
-    boundary (start points, plus the end point of the last segment in each section).
-    """
+    For each section the morphology points are interpolated to produce
+    equally-spaced segment boundaries.  When axon replacement is active,
+    sections 1–2 (AIS) and any section beyond the morphology are
+    interpolated along the simulated axon branch instead.
 
-    soma_pos = center[:,np.newaxis]
+    Args:
+        m: PositionedMorphology with points in global coordinates.
+        center: Soma position, shape (3,).
+        cols: (N, 2) array of (gid, section) pairs for all cells.
+        gid: GID of the cell to process.
+        replace_axons: If True, use the simulated axon for AIS/myelinated
+            sections.
+
+    Returns:
+        (3, M) array where each column is an x/y/z segment boundary position.
+    """
+    soma_pos = center[:, np.newaxis]
+    gid_mask = cols[:, 0] == gid
 
     axon_points, running_lens = None, None
-    if replace_axons: # If the axons are replaced by a stub axon, we need to get the positions thereof
-        axon_points, running_lens = get_axon_points(m,center) # Gets 3d positions and cumulative length of the axon
+    if replace_axons:
+        axon_points, running_lens = get_axon_points(m, center)
 
-    sections = np.unique(cols[np.where(cols[:,0]==gid),1:].flatten()) # List of sections for the given neuron
+    sections = np.unique(cols[np.where(gid_mask), 1:].flatten())
 
-    # Start with soma position(s)
-    xyz = soma_pos.reshape(3,1)
+    # Build soma columns — all somatic segments share the same position
+    num_somas = np.sum(gid_mask & (cols[:, 1] == 0))
+    xyz = np.tile(soma_pos.reshape(3, 1), num_somas)
 
-    num_somas = np.sum((cols[:,0] == gid) & (cols[:,1] == 0))
+    for sec_name in sections[1:]:
+        num_compartments = np.sum(gid_mask & (cols[:, 1] == sec_name))
 
-    if num_somas > 1: # If there is more than one somatic segment, we assume that they all have the same position
-        for k in np.arange(1,num_somas):
-            xyz = np.hstack((xyz,soma_pos.reshape(3,1)))
-
-    for sec_name in list(sections[1:]):
-
-        num_compartments = np.sum((cols[:,0] == gid) & (cols[:,1] == sec_name))
-
-        # Section 1 and 2 are always axonal when axons are replaced (AIS)
         if sec_name < 3 and replace_axons:
-            seg_pos = interp_points_axon(axon_points,running_lens,sec_name,num_compartments)
+            seg_pos = interp_points_axon(axon_points, running_lens, sec_name, num_compartments)
         else:
             sec_id = sec_name - 1
-            if sec_id >= len(m.indices): # Beyond morphology sections → myelinated AIS
-                seg_pos = interp_points_axon(axon_points,running_lens,sec_name,num_compartments)
+            if sec_id >= len(m.indices):
+                # Beyond morphology sections → myelinated AIS
+                seg_pos = interp_points_axon(axon_points, running_lens, sec_name, num_compartments)
             else:
                 sec_pts = np.array(m.section_points(sec_id))
-                seg_pos = interp_points(sec_pts,num_compartments)
+                seg_pos = interp_points(sec_pts, num_compartments)
 
-        xyz = np.hstack((xyz,seg_pos.T))
+        xyz = np.hstack((xyz, seg_pos.T))
 
     return xyz
 
@@ -579,7 +592,7 @@ def get_positions(
         )
         center = cell.local_to_global_matrix[:, 3]
 
-        cell_arrays.append(get_cell_positions(m, center, cols, i, replace_axons))
+        cell_arrays.append(_get_cell_positions(m, center, cols, i, replace_axons))
 
         cols_for_gid = cols[cols[:, 0] == i]
         neurite_type_arrays.append(resolve_neurite_types(cols_for_gid, cell))

--- a/bluerecording/positions.py
+++ b/bluerecording/positions.py
@@ -476,7 +476,7 @@ def _get_cell_positions(
 
     return xyz
 
-def resolve_neurite_types(cols_for_gid, cell):
+def resolve_neurite_types(cols_for_gid: np.ndarray, cell) -> np.ndarray:
     """Return an int array of neurite-type codes for one neuron's compartments.
 
     Queries the actual NEURON section via ``cell.get_sec()`` and maps the

--- a/bluerecording/positions.py
+++ b/bluerecording/positions.py
@@ -68,29 +68,37 @@ class PositionedMorphology:
         return self._points[self.indices[sec_id]]
 
 
-def interp_points(coords, ncomps):
+def interp_points(coords: np.ndarray, ncomps: int) -> np.ndarray:
+    """Interpolate segment boundary points along a dendritic section.
 
-    '''
-    For a given dendritic section with 3d points coords and a number of segments ncomps, we interpolate the start and end points of each segment,
-    with each segment having equal length
-    '''
+    Given the 3D points of a section and a number of compartments, returns
+    equally-spaced boundary points by linear interpolation along the arc length.
+    Consecutive duplicate points (which can arise from float32 rotation
+    precision) are removed before interpolation.
 
-    # Remove consecutive duplicate points that can arise from float32 rotation precision
+    Args:
+        coords: (P, 3) array of 3D section points.
+        ncomps: Number of compartments (segments) in the section.
+
+    Returns:
+        (ncomps + 1, 3) array of interpolated boundary positions.
+    """
+
+    # --- 1. Remove consecutive near-duplicate points (float32 rotation artefacts) ---
     diffs = np.linalg.norm(np.diff(coords, axis=0), axis=1)
-    mask = np.concatenate(([True], diffs > 0))
+    mask = np.concatenate(([True], diffs > 0))  # exact dedup only
     coords = coords[mask]
 
-    xyz = np.array([]).reshape(ncomps + 1, 0)
+    # --- 2. Interpolate equally-spaced boundary points along the arc length ---
+    arc = np.cumsum(np.linalg.norm(np.diff(coords, axis=0), axis=1))
+    arc = np.insert(arc, 0, 0)
+    arc /= arc[-1]  # normalise to [0, 1]
 
-    distances = np.cumsum(np.linalg.norm(np.diff(coords,axis=0),axis=1))
-    distances /= distances[-1]
-    distances = np.insert(distances,0,0)
-
-    for dim in range(coords.shape[1]):
-
-        f = interp1d(distances, coords[:, dim], kind='linear')
-        ic = f(np.linspace(0, 1, ncomps + 1)).reshape(ncomps + 1, 1)
-        xyz = np.hstack((xyz, ic))
+    targets = np.linspace(0, 1, ncomps + 1)
+    xyz = np.column_stack([
+        interp1d(arc, coords[:, dim], kind='linear')(targets)
+        for dim in range(coords.shape[1])
+    ])
 
     return xyz
 

--- a/bluerecording/positions.py
+++ b/bluerecording/positions.py
@@ -390,37 +390,35 @@ def interp_points_axon(
 
     return seg_pos
 
-def getNewIndex(cols):
+def get_new_index(cols: np.ndarray) -> pd.MultiIndex:
     """Build a new MultiIndex by duplicating certain (id, section) column tuples.
 
-    Rules:
-    - Every column is kept once.
-    - The last column is repeated to represent the end point.
-    - Columns with section != 0 are duplicated if the next column tuple differs.
+    Each column is kept once.  Non-somatic columns (section != 0) are
+    duplicated when the next column tuple differs, to represent the end
+    point of that section.  The last column is always repeated.
 
-    Returns a pandas MultiIndex with levels ["id", "section"].
+    Args:
+        cols: (N, 2) array of (id, section) pairs.
+
+    Returns:
+        MultiIndex with levels ["id", "section"].
     """
-    newIdx = []
-
-    # Ensure cols is a list of tuples
+    new_idx = []
     cols_list = [tuple(c) for c in cols]
 
     for i, col in enumerate(cols_list):
-        newIdx.append(col)
+        new_idx.append(col)
 
         # Last column: repeat to account for end point
         if i == len(cols_list) - 1:
-            newIdx.append(col)
+            new_idx.append(col)
 
         # Non-somatic segments: add extra entry if next col is different
-        elif col[-1] != 0:  # section != 0
-            if cols_list[i + 1] != col:  # now comparing tuples
-                newIdx.append(col)
+        elif col[-1] != 0:
+            if cols_list[i + 1] != col:
+                new_idx.append(col)
 
-    newCols = pd.MultiIndex.from_tuples(newIdx, names=["id", "section"])
-
-    return newCols
-
+    return pd.MultiIndex.from_tuples(new_idx, names=["id", "section"])
 
 def get_cell_positions(m, center, cols, gid, replace_axons):
     """Compute the 3D segment boundary positions for a single cell.
@@ -464,8 +462,6 @@ def get_cell_positions(m, center, cols, gid, replace_axons):
         xyz = np.hstack((xyz,seg_pos.T))
 
     return xyz
-
-
 
 def resolve_neurite_types(cols_for_gid, cell):
     """Return an int array of neurite-type codes for one neuron's compartments.
@@ -594,14 +590,11 @@ def get_positions(
         return positions_df, cols, np.array([], dtype=np.int32)
 
     xyz = np.hstack(cell_arrays)
-    new_cols = getNewIndex(cols)
+    new_cols = get_new_index(cols)
     positions_df = pd.DataFrame(xyz, columns=new_cols)
     neurite_types = np.concatenate(neurite_type_arrays)
 
     return positions_df, cols, neurite_types
-
-
-
 
 def save_positions(positions_df: pd.DataFrame, path_to_positions_folder: str | Path) -> None:
     """Write positions DataFrame to a pickle file for this MPI rank.

--- a/bluerecording/positions.py
+++ b/bluerecording/positions.py
@@ -1,7 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import json
-import os
-
 import libsonata
 import numpy as np
 import pandas as pd
@@ -10,8 +7,6 @@ from morphio import Morphology, SectionType
 from mpi4py import MPI
 from pathlib import Path
 from scipy.interpolate import interp1d
-
-from .utils import get_circuit_path
 
 rank = MPI.COMM_WORLD.Get_rank()
 
@@ -395,107 +390,6 @@ def interp_points_axon(
 
     return seg_pos
 
-def remove_variables(js, finalmorphpath):
-
-    '''
-    Removes references to variables in path to morphology
-    Assumes that all references are in the manifest section
-    '''
-
-    while '$' in finalmorphpath:
-
-        elements = finalmorphpath.split('/')
-
-        for i, element in enumerate(elements):
-
-            if '$' in element:
-                element = js['manifest'][element]
-                
-            if i == 0:
-                finalmorphpath = element
-            else:
-                finalmorphpath = finalmorphpath + '/' + element
-
-    return finalmorphpath
-
-def tryFileNames(morphName, finalmorphpath):
-
-    asc = finalmorphpath+'/ascii/'+morphName+'.asc'
-    asc1 = finalmorphpath+'/'+morphName+'.asc'
-    asc2 = finalmorphpath+'/morphologies_asc/'+morphName+'.asc'
-
-    swc = finalmorphpath+'/swc/'+morphName+'.swc'
-    swc1 = finalmorphpath+'/'+morphName+'.swc'
-    swc2 = finalmorphpath+'/morphologies_swc/'+morphName+'.swc'
-
-    options = [asc, asc1, asc2, swc, swc1, swc2]
-
-    for option in options:
-        if os.path.exists(option):
-            fileName = option
-            break
-
-    return fileName
-
-def get_morph_path(population, i, path_to_simconfig):
-
-    morphName = population.get_attribute('morphology', i) # Gets name of the morphology file for node_id i
-
-    circuitpath = get_circuit_path(path_to_simconfig) # path to circuit_config file
-
-    with open(circuitpath) as f: # Gets path to morphology file from circuit_config
-
-        js = json.load(f)
-
-        if 'components' in js.keys() and 'morphologies_dir' in js['components'].keys():
-            finalmorphpath = js['components']['morphologies_dir']
-
-        else:
-            finalmorphpath = js['manifest']['$MORPHOLOGIES']
-
-        finalmorphpath = remove_variables(js, finalmorphpath)
-
-        finalmorphpath = str((Path(circuitpath).parent / finalmorphpath).resolve())
-
-    fileName = tryFileNames(morphName, finalmorphpath)
-
-    return fileName
-
-
-def get_morphology(
-    population: libsonata.NodePopulation,
-    i: int,
-    path_to_simconfig: str,
-    cell,
-) -> tuple[PositionedMorphology, np.ndarray]:
-    """Load and transform a morphology into circuit (global) coordinates.
-
-    Args:
-        population: libsonata NodePopulation.
-        i: Node index within the population.
-        path_to_simconfig: Path to the SONATA simulation configuration file.
-        cell: Neurodamus cell object with coordinate mapping.
-
-    Returns:
-        m: PositionedMorphology with points transformed to global coordinates.
-        center: (3,) float32 array — the soma position taken from the sonata
-            node x/y/z (translation column of the transform matrix).  This is
-            the BlueRecording convention (raw placement position), not the
-            neurodamus soma centroid (mean of NEURON soma section boundary
-            points), which can differ by up to ~1.8 µm.
-    """
-
-    finalmorphpath = get_morph_path(population, i, path_to_simconfig)
-
-    mImmutable = Morphology(finalmorphpath) # Immutable MorphIO morphology object
-
-    m = PositionedMorphology(mImmutable, transform=cell.local_to_global_coord_mapping)
-
-    center = cell.local_to_global_matrix[:, 3]
-
-    return m, center
-
-
 def getNewIndex(cols):
     """Build a new MultiIndex by duplicating certain (id, section) column tuples.
 
@@ -604,6 +498,36 @@ def resolve_neurite_types(cols_for_gid, cell):
     return result
 
 
+def _find_morph_file(morph_name: str, morph_dir: str) -> str:
+    """Locate a morphology file by trying common subdirectory/extension combos.
+
+    Args:
+        morph_name: Morphology name (without extension) from the population.
+        morph_dir: Absolute path to the morphologies directory (from libsonata).
+
+    Returns:
+        Absolute path to the first existing morphology file found.
+
+    Raises:
+        FileNotFoundError: If no matching file is found.
+    """
+    base = Path(morph_dir)
+    candidates = [
+        base / "ascii" / f"{morph_name}.asc",
+        base / f"{morph_name}.asc",
+        base / "morphologies_asc" / f"{morph_name}.asc",
+        base / "swc" / f"{morph_name}.swc",
+        base / f"{morph_name}.swc",
+        base / "morphologies_swc" / f"{morph_name}.swc",
+    ]
+    for path in candidates:
+        if path.exists():
+            return str(path)
+    raise FileNotFoundError(
+        f"Morphology '{morph_name}' not found in {morph_dir}"
+    )
+
+
 def get_positions(node_manager, ids, cols, population, path_to_simconfig, replace_axons=True):
     """Compute segment boundary positions for all cells on this rank.
 
@@ -628,9 +552,29 @@ def get_positions(node_manager, ids, cols, population, path_to_simconfig, replac
     """
     cell_arrays = []
     neurite_type_arrays = []
+
+    # Resolve morphologies directory once via libsonata (replaces manual
+    # JSON parsing + manifest variable substitution that lived in the
+    # now-deleted get_morph_path / remove_variables / tryFileNames).
+    sim_conf = libsonata.SimulationConfig.from_file(path_to_simconfig)
+    circuit_conf = libsonata.CircuitConfig.from_file(sim_conf.network)
+    pop_name = node_manager.population_name
+    morph_dir = circuit_conf.node_population_properties(pop_name).morphologies_dir
+
     for i in ids:
         cell = node_manager.get_cell(i)
-        m, center = get_morphology(population, i, path_to_simconfig, cell)
+
+        # Load morphology, transform to global coordinates, extract soma pos.
+        # center is the raw placement position (translation column of the
+        # transform matrix), not the neurodamus soma centroid which can
+        # differ by up to ~1.8 µm.
+        morph_name = population.get_attribute("morphology", i)
+        morph_path = _find_morph_file(morph_name, morph_dir)
+        m = PositionedMorphology(
+            Morphology(morph_path),
+            transform=cell.local_to_global_coord_mapping,
+        )
+        center = cell.local_to_global_matrix[:, 3]
 
         cell_arrays.append(get_cell_positions(m, center, cols, i, replace_axons))
 

--- a/bluerecording/positions.py
+++ b/bluerecording/positions.py
@@ -299,102 +299,101 @@ def get_axon_points(m: PositionedMorphology, center: np.ndarray) -> tuple[np.nda
     return axon_points, np.array(running_len)[indices]
 
 
-def interp_points_axon(axonPoints, runningLens, secName, numCompartments, somaPos):
+def interp_points_axon(
+    axon_points: np.ndarray,
+    running_lens: np.ndarray,
+    sec_name: int,
+    num_compartments: int,
+) -> np.ndarray:
+    """Interpolate segment boundary points for a simulated-axon section.
 
-    segPos = []
+    The simulated axon has three sections identified by *sec_name*:
 
+    * 1 — first AIS section  (0–30 µm)
+    * 2 — second AIS section (30–60 µm)
+    * 3+ — myelinated section (60–1060 µm)
 
-    if secName == 1: # First AIS section
+    For each section the relevant subset of *axon_points* is selected by
+    cumulative arc length, then linearly interpolated to produce equally-spaced
+    segment boundary positions.  When fewer than two morphology points fall
+    inside the section's length window, nearby points are used as fallback
+    anchors so that extrapolation can still proceed.
 
-        secLen = 30 # By construction, has length of 30 um
-        segLen = secLen / numCompartments # Assumes each segment has the same length
+    Args:
+        axon_points: (N, 3) array of 3D positions along the axonal branch.
+        running_lens: (N,) array of cumulative arc lengths aligned with
+            *axon_points*.
+        sec_name: Section identifier (1 = first AIS, 2 = second AIS,
+            ≥3 = myelinated).
+        num_compartments: Number of compartments (segments) in this section.
 
-        startPoint = 0
-        endPoint = 30
+    Returns:
+        (num_compartments + 1, 3) array of interpolated boundary positions.
+    """
 
-        idx = np.where(runningLens <= endPoint) # Finds indices of axon 3d points where cumulative length < 30 um
+    # --- 1. Determine section geometry and select relevant points ---
 
-        axonRelevant = axonPoints[idx]
+    if sec_name == 1:  # First AIS section (0–30 µm)
+        sec_len = 30
+        start, end = 0, 30
 
+        idx = np.where(running_lens <= end)
+        axon_relevant = axon_points[idx]
+        lens_relevant = running_lens[idx] / sec_len
 
-        lensRelevant = runningLens[idx] / secLen # Gets fraction of the total section length for each 3d point
+        if len(axon_relevant) < 2:
+            axon_relevant = axon_points[:2]
+            lens_relevant = running_lens[:2] / sec_len
 
+    elif sec_name == 2:  # Second AIS section (30–60 µm)
+        sec_len = 30
+        start, end = 30, 60
 
-        if len(axonRelevant) < 2: # If there are not enough points, we use the soma position (which would be included in the axon point list) and the first real point in the axon
-            idx = 0
+        idx = np.intersect1d(
+            np.where(running_lens <= end),
+            np.where(running_lens >= start),
+        )
+        axon_relevant = axon_points[idx]
+        lens_relevant = (running_lens[idx] - start) / sec_len
 
-            axonRelevant = axonPoints[:2]
+        if len(axon_relevant) < 2:
+            idx_lo = np.argmin(np.abs(running_lens - start))
+            idx_hi = np.argmin(np.abs(running_lens - end))
 
-            lensRelevant = runningLens[:2] / secLen
-
-
-    elif secName == 2: # Second AIS section
-
-        secLen = 30 # Length is 30 unm, by construction
-        segLen = secLen / numCompartments
-
-        startPoint = 30 # Cumulative length of first AIS section
-        endPoint = 60 # Cumulative length of both AIS sections
-
-        idx = np.intersect1d(np.where(runningLens <= endPoint), np.where(runningLens >= startPoint)) # Finds indices 3d points falling in this length bin
-
-        axonRelevant = axonPoints[idx]
-
-        lensRelevant = (runningLens[idx] - startPoint) / secLen
-
-        if len(axonRelevant) < 2: # If there aren't enough points, we estimate
-
-            idxSmall = np.argmin(np.abs(runningLens - startPoint)) # Index closest to 30 um
-
-            idxBig = np.argmin(np.abs(runningLens - endPoint)) # Index closest to 60 um
-
-            if idxSmall == idxBig: # If these two points are the same, we use different points
-                if idxBig < len(runningLens)-1:
-                    idxBig += 1
+            if idx_lo == idx_hi:
+                if idx_hi < len(running_lens) - 1:
+                    idx_hi += 1
                 else:
-                    idxSmall -= 1 # If the two points are identical, then idxSmall can never be zero, since otherwise this would imply a one-point axon
+                    idx_lo -= 1
 
-            idx = [idxSmall, idxBig]
+            idx = [idx_lo, idx_hi]
+            axon_relevant = axon_points[idx]
+            lens_relevant = (running_lens[idx] - start) / sec_len
 
-            axonRelevant = axonPoints[idx]
-            lensRelevant = (runningLens[idx] - startPoint) / secLen
+    else:  # Myelinated section (60–1060 µm)
+        sec_len = 1000
+        start, end = 60, 1060
 
-
-    else: # Myelinated section
-
-        secLen = 1000
-        segLen = secLen / numCompartments
-
-        startPoint = 60
-        endPoint = 1060
-
-        idx = np.where(runningLens >= startPoint)[0] # Get indices of 3d points that are beyond the AIS
+        idx = np.where(running_lens >= start)[0]
 
         if len(idx) == 1:
             idx = [idx[0] - 1, idx[0]]
 
-        axonRelevant = axonPoints[idx]
+        axon_relevant = axon_points[idx]
+        lens_relevant = (running_lens[idx] - start) / sec_len
 
-        lensRelevant = (runningLens[idx] - startPoint) / secLen
+    # --- 2. Interpolate equally-spaced boundary points ---
 
-    for i in range(numCompartments+1): # Interpolates segment positions
+    seg_len = sec_len / num_compartments
+    targets = np.array([(i * seg_len) / sec_len for i in range(num_compartments + 1)])
 
-        frac = (i * segLen) / secLen
+    seg_pos = np.column_stack([
+        interp1d(lens_relevant, axon_relevant[:, dim], kind='linear',
+                 fill_value='extrapolate')(targets)
+        for dim in range(3)
+    ])
 
-
-        fx = interp1d(lensRelevant, axonRelevant[:, 0], kind='linear', fill_value='extrapolate')
-        fy = interp1d(lensRelevant, axonRelevant[:, 1], kind='linear', fill_value='extrapolate')
-        fz = interp1d(lensRelevant, axonRelevant[:, 2], kind='linear', fill_value='extrapolate')
-
-        newx = fx(frac)
-        newy = fy(frac)
-        newz = fz(frac)
-
-        segPos.append([newx, newy, newz])
-
-
-    segPos = np.array(segPos)
-    return segPos
+    return seg_pos
 
 def remove_variables(js, finalmorphpath):
 
@@ -559,11 +558,11 @@ def get_cell_positions(m, center, cols, gid, replace_axons):
 
         # Section 1 and 2 are always axonal when axons are replaced (AIS)
         if sec_name < 3 and replace_axons:
-            seg_pos = interp_points_axon(axon_points,running_lens,sec_name,num_compartments,soma_pos)
+            seg_pos = interp_points_axon(axon_points,running_lens,sec_name,num_compartments)
         else:
             sec_id = sec_name - 1
             if sec_id >= len(m.indices): # Beyond morphology sections → myelinated AIS
-                seg_pos = interp_points_axon(axon_points,running_lens,sec_name,num_compartments,soma_pos)
+                seg_pos = interp_points_axon(axon_points,running_lens,sec_name,num_compartments)
             else:
                 sec_pts = np.array(m.section_points(sec_id))
                 seg_pos = interp_points(sec_pts,num_compartments)

--- a/tests/unit/test_positions.py
+++ b/tests/unit/test_positions.py
@@ -76,7 +76,7 @@ def test_interpolate_ais(tmp_path):
     sec_name = sections[1]
     num_compartments = np.shape(data[1][sec_name])[-1]
     axon_pts, running_lens = positions.get_axon_points(morph, SOMA_POS)
-    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments, SOMA_POS)
+    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments)
     np.testing.assert_almost_equal(seg_pos, [[0, 0, 0], [0, 0, 6], [0, 0, 12], [0, 0, 18], [0, 0, 24], [0, 0, 30]], decimal=2)
 
 
@@ -88,7 +88,7 @@ def test_interpolate_ais_far_axon(tmp_path):
     sec_name = sections[1]
     num_compartments = np.shape(data[1][sec_name])[-1]
     axon_pts, running_lens = positions.get_axon_points(morph, SOMA_POS)
-    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments, SOMA_POS)
+    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments)
     np.testing.assert_almost_equal(seg_pos, [[0, 0, 0], [0, 0, 6], [0, 0, 12], [0, 0, 18], [0, 0, 24], [0, 0, 30]], decimal=2)
 
 
@@ -100,7 +100,7 @@ def test_interpolate_ais_short(tmp_path):
     sec_name = sections[1]
     num_compartments = np.shape(data[1][sec_name])[-1]
     axon_pts, running_lens = positions.get_axon_points(morph, SOMA_POS)
-    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments, SOMA_POS)
+    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments)
     np.testing.assert_almost_equal(seg_pos, [[0, 0, 0], [0, 0, 6], [0, 0, 12], [0, 0, 18], [0, 0, 24], [0, 0, 30]], decimal=2)
 
 
@@ -112,7 +112,7 @@ def test_interpolate_ais_2(tmp_path):
     sec_name = sections[2]
     num_compartments = np.shape(data[1][sec_name])[-1]
     axon_pts, running_lens = positions.get_axon_points(morph, SOMA_POS)
-    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments, SOMA_POS)
+    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments)
     np.testing.assert_almost_equal(seg_pos, [[0, 0, 30], [0, 0, 36], [0, 0, 42], [0, 0, 48], [0, 0, 54], [0, 0, 60]], decimal=2)
 
 
@@ -124,7 +124,7 @@ def test_interpolate_ais_2_short(tmp_path):
     sec_name = sections[2]
     num_compartments = np.shape(data[1][sec_name])[-1]
     axon_pts, running_lens = positions.get_axon_points(morph, SOMA_POS)
-    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments, SOMA_POS)
+    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments)
     np.testing.assert_almost_equal(seg_pos, [[0, 0, 30], [0, 0, 36], [0, 0, 42], [0, 0, 48], [0, 0, 54], [0, 0, 60]], decimal=2)
 
 
@@ -135,7 +135,7 @@ def test_interpolate_myelin(tmp_path):
     sec_name = sections[-1]
     num_compartments = np.shape(data[1][sec_name])[-1]
     axon_pts, running_lens = positions.get_axon_points(morph, SOMA_POS)
-    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments, SOMA_POS)
+    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments)
     np.testing.assert_almost_equal(seg_pos, [[0, 0, 60], [0, 0, 260], [0, 0, 460], [0, 0, 660], [0, 0, 860], [0, 0, 1060]], decimal=2)
 
 
@@ -146,7 +146,7 @@ def test_interpolate_myelin_short(tmp_path):
     sec_name = sections[-1]
     num_compartments = np.shape(data[1][sec_name])[-1]
     axon_pts, running_lens = positions.get_axon_points(morph, SOMA_POS)
-    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments, SOMA_POS)
+    seg_pos = positions.interp_points_axon(axon_pts, running_lens, sec_name, num_compartments)
     np.testing.assert_almost_equal(seg_pos, [[0, 0, 60], [0, 0, 260], [0, 0, 460], [0, 0, 660], [0, 0, 860], [0, 0, 1060]], decimal=2)
 
 

--- a/tests/unit/test_positions.py
+++ b/tests/unit/test_positions.py
@@ -54,7 +54,7 @@ def test_get_new_idx():
     ]
     expected_idx = list(zip(*expected_columns))
     expected_mi = pd.MultiIndex.from_tuples(expected_idx, names=['id', 'section'])
-    result = positions.getNewIndex(data.columns)
+    result = positions.get_new_index(data.columns)
     pd.testing.assert_index_equal(result, expected_mi)
 
 


### PR DESCRIPTION
## Context

Fix: #52

## Scope

- Removed `remove_variables`, `tryFileNames`, `get_morph_path`, and `get_morphology` 
- replaced manual JSON parsing and manifest variable substitution with `libsonata.CircuitConfig.node_population_properties().morphologies_dir`
- Removed `MutableMorph` class, replaced by `PositionedMorphology` (immutable MorphIO wrapper with optional coordinate transform)
- Removed `concretize_path` from utils, inlined with `pathlib.Path.resolve()`
- Removed dead `sys.argv` parsing helpers from utils, inlined `processSubsampling` into weights
- Removed unused imports (`json`, `os`, `warnings`, `from .utils import *`, `from .circuit import init_circuit`)
- Removed global `warnings.filterwarnings('error', '', RuntimeWarning)`
- `get_axon_points`: extracted into `_get_cumulative_length`, `_get_branch_section_ids`, `_find_best_axon_branch`, `_collect_branch_points`, `_extrapolate_branch` — lazy memoized cumulative lengths
- `interp_points`: proper docstring, type hints, `np.column_stack` instead of hstack loop
- `interp_points_axon`: docstring, type hints, snake_case params, removed unused `soma_pos` parameter, build interpolators once via `np.column_stack`
- `_get_cell_positions` (was `get_cell_positions`): made private, type hints, docstring, `np.tile` for soma duplication, single `gid_mask`
- `getNewIndex` → `get_new_index`: snake_case, type hints
- `PositionedMorphology`: added type hints and docstrings to all properties and methods
- `utils.py`: snake_case, type hints, moved dead code to example script
- type hinting, doc strings and adoption of snake_case