### PR TITLE
add PyPI publish workflow on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+
+on: [pull_request, push, workflow_dispatch]
+
+jobs:
+  wheel:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python_version: ["3.11"]
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for hatch-vcs to resolve version from tags
+
+      - name: Build Wheel
+        run: |
+          cd $GITHUB_WORKSPACE
+          python${{ matrix.python_version }} -m pip install --upgrade build
+          python${{ matrix.python_version }} -m build .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts-${{ matrix.python_version }}-${{ strategy.job-index }}
+          path: ./dist/*
+
+  pypi-publish:
+    runs-on: ubuntu-22.04
+    needs: [wheel]
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts produced by the wheel job
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-artifacts*
+          path: dist/
+          merge-multiple: true
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: dist
+
+      - name: Publish to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages_dir: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,12 @@ jobs:
         python_version: ["3.11"]
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # needed for hatch-vcs to resolve version from tags
 
@@ -25,7 +25,7 @@ jobs:
           python${{ matrix.python_version }} -m pip install --upgrade build
           python${{ matrix.python_version }} -m build .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: release-artifacts-${{ matrix.python_version }}-${{ strategy.job-index }}
           path: ./dist/*
@@ -37,7 +37,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts produced by the wheel job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: release-artifacts*
           path: dist/


### PR DESCRIPTION
## Context

Fix #63

## Scope

Adds a GitHub Actions workflow (`.github/workflows/publish.yml`) that:

- Builds sdist + wheel on every push, PR, and manual trigger (catches build issues early)
- Publishes to PyPI automatically when a tag is pushed
- Uses OIDC trusted publishing (no API tokens needed)
- Follows the same pattern as neurodamus's `publish_wheels.yml`

## Before merging

A Trusted Publisher must be registered on PyPI:
- PyPI project name: `bluerecording`
- Owner: `openbraininstitute`
- Repository: `BlueRecording`
- Workflow name: `publish.yml`

Once merged, pushing a semver tag (e.g. `0.4.0`) will trigger the publish.
