### PR TITLE
Split data download into standalone script, expand mpi4py comment, drop bytewise test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Use `--clean-install` to wipe the virtual environment and all build artifacts be
 source env.sh
 ```
 
-If you want to run the full testing suite you need `--data`. See the [Testing](#testing) section for details.
+If you want to run the full testing suite you need to download the example data. See the [Testing](#testing) section for details.
 
 ---
 # Input data
@@ -75,10 +75,11 @@ In subsequent sessions, running `source env.sh` will activate the existing envir
 ---
 # Testing
 
-First, make sure you have set up the development environment with test data:
+First, make sure you have set up the development environment and downloaded the test data:
 
 ```bash
-./dev_setup.sh --data
+./dev_setup.sh
+./download_examples_data.sh
 source env.sh
 ```
 

--- a/bluerecording/__init__.py
+++ b/bluerecording/__init__.py
@@ -27,10 +27,10 @@ def _check_dependencies():
         )
 
     try:
-        # noqa: F401 — mpi4py must be imported before neuron to ensure MPI is
-        # initialized. This is necessary when NEURON is compiled with
-        # -DNRN_ENABLE_MPI_DYNAMIC=OFF, as NEURON will not dynamically load
-        # MPI support at runtime and expects MPI to already be initialized.
+        # noqa: F401 — mpi4py must be imported before neuron to ensure
+        # MPI_Init has been called. When NEURON is statically linked against
+        # MPI (NRN_ENABLE_MPI_DYNAMIC=OFF), it expects MPI to already be
+        # initialized by the time it loads.
         from mpi4py import MPI  # noqa: F401
         import neuron  # noqa: F401
     except ImportError:

--- a/bluerecording/__init__.py
+++ b/bluerecording/__init__.py
@@ -31,7 +31,7 @@ def _check_dependencies():
         # initialized. This is necessary when NEURON is compiled with
         # -DNRN_ENABLE_MPI_DYNAMIC=OFF, as NEURON will not dynamically load
         # MPI support at runtime and expects MPI to already be initialized.
-        import mpi4py  # noqa: F401
+        from mpi4py import MPI  # noqa: F401
         import neuron  # noqa: F401
     except ImportError:
         raise ImportError(

--- a/bluerecording/__init__.py
+++ b/bluerecording/__init__.py
@@ -27,6 +27,11 @@ def _check_dependencies():
         )
 
     try:
+        # noqa: F401 — mpi4py must be imported before neuron to ensure MPI is
+        # initialized. This is necessary when NEURON is compiled with
+        # -DNRN_ENABLE_MPI_DYNAMIC=OFF, as NEURON will not dynamically load
+        # MPI support at runtime and expects MPI to already be initialized.
+        import mpi4py  # noqa: F401
         import neuron  # noqa: F401
     except ImportError:
         raise ImportError(

--- a/bluerecording/positions.py
+++ b/bluerecording/positions.py
@@ -566,7 +566,7 @@ def get_positions(node_manager, ids, cols, population, morphologies_dir, replace
     neurite_type_arrays = []
     for i in ids:
         cell = node_manager.get_cell(i)
-        m, center = get_morphology(population, i, morphologies_dir, cell)
+        m, center = get_morphology(population, cell.raw_gid, morphologies_dir, cell)
 
         cell_arrays.append(get_cell_positions(m, center, cols, i, replace_axons))
 

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -22,7 +22,6 @@ NEURON_COMMIT="9.0.1"
 NEURODAMUS_COMMIT="4.2.1"
 
 SKIP_SYSTEM=0
-DOWNLOAD_DATA=0
 CLEAN_INSTALL=0
 
 # -------------------------
@@ -31,7 +30,6 @@ CLEAN_INSTALL=0
 for arg in "$@"; do
     case $arg in
         --no-system) SKIP_SYSTEM=1 ;;
-        --data) DOWNLOAD_DATA=1 ;;
         --clean-install) CLEAN_INSTALL=1 ;;
         --help|-h)
             echo "Usage: ./dev_setup.sh [OPTIONS]"
@@ -44,7 +42,6 @@ for arg in "$@"; do
             echo ""
             echo "Options:"
             echo "  --no-system      Skip system package installation (brew/apt)"
-            echo "  --data           Download and unpack example datasets (atlas, networks, FEM)"
             echo "  --clean-install  Remove venv, cloned repos, and build artifacts (keeps data)"
             echo "  --help, -h       Show this help message"
             exit 0
@@ -282,80 +279,7 @@ echo "To activate the environment, run:"
 echo ""
 echo "    source env.sh"
 echo ""
-
-# -------------------------
-# Download data if requested via --data
-# -------------------------
-if [[ "$DOWNLOAD_DATA" == "1" ]]; then
-    ATLAS_DIR="examples/data/atlas"
-
-    if [ -d "$ATLAS_DIR" ] && [ "$(ls -A "$ATLAS_DIR")" ]; then
-        echo "=== Skipping atlas download — $ATLAS_DIR already exists and is not empty ==="
-    else
-        echo "=== Downloading atlas dataset ==="
-        mkdir -p examples/data
-        curl -L -o examples/data/atlas.zip \
-            "https://zenodo.org/record/10927050/files/atlas.zip?download=1"
-
-        echo "=== Unpacking atlas dataset ==="
-        unzip -q examples/data/atlas.zip -d examples/data
-
-        echo "=== Cleaning up ==="
-        rm examples/data/atlas.zip
-
-        echo "=== Atlas dataset ready at $ATLAS_DIR ==="
-    fi
-
-    # -------------------------
-    # Download networks data
-    # -------------------------
-    CONFIG_DIR="examples/sscx_100_cells/configuration"
-    NETWORK_DIR="$CONFIG_DIR/networks"
-
-    if [ -d "$NETWORK_DIR" ] && [ "$(ls -A "$NETWORK_DIR")" ]; then
-        echo "=== Skipping networks download — $NETWORK_DIR already exists and is not empty ==="
-    else
-        echo "=== Downloading networks dataset ==="
-
-        mkdir -p "$CONFIG_DIR"
-
-        curl -L -o networks.zip \
-            "https://zenodo.org/record/10927050/files/networks.zip?download=1"
-
-        echo "=== Unpacking networks dataset ==="
-        unzip -q networks.zip -d "$CONFIG_DIR"
-
-        echo "=== Cleaning up ==="
-        rm networks.zip
-
-        echo "=== Networks dataset ready at $NETWORK_DIR ==="
-    fi
-
-    # -------------------------
-    # Download single_cell_l5_tpc FEM field files
-    # -------------------------
-    L5_TPC_DIR="examples/single_cell_l5_tpc"
-    L5_TPC_FILE1="$L5_TPC_DIR/Infinite_VeryFar_HighRes.h5"
-    L5_TPC_FILE2="$L5_TPC_DIR/Infinite_Close_HighRes_SmallSphere.h5"
-
-    if [ -f "$L5_TPC_FILE1" ] && [ -f "$L5_TPC_FILE2" ]; then
-        echo "=== Skipping single_cell_l5_tpc FEM field download — files already exist ==="
-    else
-        echo "=== Downloading single_cell_l5_tpc FEM field files ==="
-        mkdir -p "$L5_TPC_DIR"
-
-        if [ ! -f "$L5_TPC_FILE1" ]; then
-            curl -L -o "$L5_TPC_FILE1" \
-                "https://zenodo.org/record/10927050/files/Infinite_VeryFar_HighRes.h5?download=1"
-        fi
-
-        if [ ! -f "$L5_TPC_FILE2" ]; then
-            curl -L -o "$L5_TPC_FILE2" \
-                "https://zenodo.org/record/10927050/files/Infinite_Close_HighRes_SmallSphere.h5?download=1"
-        fi
-
-        echo "=== single_cell_l5_tpc FEM field files ready ==="
-    fi
-else
-    echo "=== Skipping data download — --data not given ==="
-fi
+echo "To download example datasets (atlas, networks, FEM fields), run:"
+echo ""
+echo "    ./download_examples_data.sh"
+echo ""

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -99,8 +99,12 @@ if [[ $SKIP_SYSTEM -eq 0 ]]; then
 
     elif [[ "$OS" == "Linux" ]]; then
         echo "Linux detected"
-        sudo apt update
-        sudo apt install -y \
+        SUDO=""
+        if [[ $(id -u) -ne 0 ]] && command -v sudo &>/dev/null; then
+            SUDO="sudo"
+        fi
+        $SUDO apt update
+        $SUDO apt install -y \
             openmpi-bin \
             libopenmpi-dev \
             libhdf5-openmpi-dev \

--- a/download_examples_data.sh
+++ b/download_examples_data.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# download_examples_data.sh — Download example datasets for BlueRecording.
+#
+# Downloads atlas, network, and FEM field data from Zenodo.
+# Idempotent: skips any dataset that is already present.
+#
+# Usage: ./download_examples_data.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# -------------------------
+# Detect OS and ensure unzip is available
+# -------------------------
+OS="$(uname -s)"
+
+if ! command -v unzip &>/dev/null; then
+    if [[ "$OS" == "Linux" ]]; then
+        echo "=== Installing unzip (required for data extraction) ==="
+        sudo apt update
+        sudo apt install -y unzip
+    else
+        echo "Error: unzip is not installed and could not be installed automatically."
+        exit 1
+    fi
+fi
+
+# -------------------------
+# Atlas dataset
+# -------------------------
+ATLAS_DIR="examples/data/atlas"
+
+if [ -d "$ATLAS_DIR" ] && [ "$(ls -A "$ATLAS_DIR")" ]; then
+    echo "=== Skipping atlas download — $ATLAS_DIR already exists and is not empty ==="
+else
+    echo "=== Downloading atlas dataset ==="
+    mkdir -p examples/data
+    curl -L -o examples/data/atlas.zip \
+        "https://zenodo.org/record/10927050/files/atlas.zip?download=1"
+
+    echo "=== Unpacking atlas dataset ==="
+    unzip -q examples/data/atlas.zip -d examples/data
+
+    echo "=== Cleaning up ==="
+    rm examples/data/atlas.zip
+
+    echo "=== Atlas dataset ready at $ATLAS_DIR ==="
+fi
+
+# -------------------------
+# Networks dataset
+# -------------------------
+CONFIG_DIR="examples/sscx_100_cells/configuration"
+NETWORK_DIR="$CONFIG_DIR/networks"
+
+if [ -d "$NETWORK_DIR" ] && [ "$(ls -A "$NETWORK_DIR")" ]; then
+    echo "=== Skipping networks download — $NETWORK_DIR already exists and is not empty ==="
+else
+    echo "=== Downloading networks dataset ==="
+
+    mkdir -p "$CONFIG_DIR"
+
+    curl -L -o networks.zip \
+        "https://zenodo.org/record/10927050/files/networks.zip?download=1"
+
+    echo "=== Unpacking networks dataset ==="
+    unzip -q networks.zip -d "$CONFIG_DIR"
+
+    echo "=== Cleaning up ==="
+    rm networks.zip
+
+    echo "=== Networks dataset ready at $NETWORK_DIR ==="
+fi
+
+# -------------------------
+# Single-cell L5 TPC FEM field files
+# -------------------------
+L5_TPC_DIR="examples/single_cell_l5_tpc"
+L5_TPC_FILE1="$L5_TPC_DIR/Infinite_VeryFar_HighRes.h5"
+L5_TPC_FILE2="$L5_TPC_DIR/Infinite_Close_HighRes_SmallSphere.h5"
+
+if [ -f "$L5_TPC_FILE1" ] && [ -f "$L5_TPC_FILE2" ]; then
+    echo "=== Skipping single_cell_l5_tpc FEM field download — files already exist ==="
+else
+    echo "=== Downloading single_cell_l5_tpc FEM field files ==="
+    mkdir -p "$L5_TPC_DIR"
+
+    if [ ! -f "$L5_TPC_FILE1" ]; then
+        curl -L -o "$L5_TPC_FILE1" \
+            "https://zenodo.org/record/10927050/files/Infinite_VeryFar_HighRes.h5?download=1"
+    fi
+
+    if [ ! -f "$L5_TPC_FILE2" ]; then
+        curl -L -o "$L5_TPC_FILE2" \
+            "https://zenodo.org/record/10927050/files/Infinite_Close_HighRes_SmallSphere.h5?download=1"
+    fi
+
+    echo "=== single_cell_l5_tpc FEM field files ready ==="
+fi
+
+echo ""
+echo "=== All example data downloaded ==="

--- a/download_examples_data.sh
+++ b/download_examples_data.sh
@@ -19,8 +19,12 @@ OS="$(uname -s)"
 if ! command -v unzip &>/dev/null; then
     if [[ "$OS" == "Linux" ]]; then
         echo "=== Installing unzip (required for data extraction) ==="
-        sudo apt update
-        sudo apt install -y unzip
+        SUDO=""
+        if [[ $(id -u) -ne 0 ]] && command -v sudo &>/dev/null; then
+            SUDO="sudo"
+        fi
+        $SUDO apt update
+        $SUDO apt install -y unzip
     else
         echo "Error: unzip is not installed and could not be installed automatically."
         exit 1

--- a/examples/single_cell_l5_tpc/README.md
+++ b/examples/single_cell_l5_tpc/README.md
@@ -4,7 +4,7 @@ Extracellular recordings from a single layer 5 thick-tufted pyramidal cell place
 
 ## Prerequisites
 
-Run `./dev_setup.sh --data` from the project root. This installs all dependencies, downloads the required datasets and creates an environment script `env.sh`. Then `source env.sh` to set up the project environment.
+Run `./dev_setup.sh` from the project root to install all dependencies, then `./download_examples_data.sh` to download the required datasets. Finally, `source env.sh` to set up the project environment.
 
 This will download the files `Infinite_VeryFar_HighRes.h5` and `Infinite_Close_HighRes_SmallSphere.h5` from [our Zenodo repository](https://zenodo.org/records/10927050) into this folder.
 

--- a/examples/sscx_100_cells/README.md
+++ b/examples/sscx_100_cells/README.md
@@ -4,7 +4,7 @@ Extracellular recordings from a network of 100 SSCx cells.
 
 ## Prerequisites
 
-Run `./dev_setup.sh --data` from the project root. This installs all dependencies, downloads the required datasets (networks and atlas) and creates an environment script `env.sh`. Then `source env.sh` to set up the project environment.
+Run `./dev_setup.sh` from the project root to install all dependencies, then `./download_examples_data.sh` to download the required datasets (networks and atlas). Finally, `source env.sh` to set up the project environment.
 
 ## Calculating Segment Positions
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # run_tests.sh — Run all tests (unit + MPI) in the dev environment.
 #
-# Assumes that './dev_setup.sh --data' has been called at least once.
+# Assumes that './dev_setup.sh' and './download_examples_data.sh' have been
+# called at least once.
 #
 # Usage:
 #   ./run_tests.sh              # run all tests

--- a/tests/unit/test_weights.py
+++ b/tests/unit/test_weights.py
@@ -378,9 +378,6 @@ def test_circuit_write_weights(tmp_path):
         dset = f"electrodes/{pop_name}/scaling_factors"
         np.testing.assert_allclose(r[dset][:], n[dset][:], rtol=1e-6, atol=1e-9)
 
-    with open(ref, "rb") as f1, open(out, "rb") as f2:
-        assert f1.read() == f2.read(), "Output differs from reference at byte level"
-
 
 @pytest.mark.skip_in_ci
 def test_single_cell_write_weights(tmp_path):


### PR DESCRIPTION
## Context

Fix: #66 #62

## Scope

- Extract data download from dev_setup.sh into download_examples_data.sh (installs unzip on Linux if missing, idempotent)
- Remove --data flag from dev_setup.sh; print hint for new script
- Expand mpi4py import comment re NRN_ENABLE_MPI_DYNAMIC=OFF
- Remove bytewise H5 comparison in test_circuit_write_weights (assert_allclose already covers numerical correctness)
- Update READMEs and run_tests.sh references
- use raw_gid for `get_attribute("morphology"...` (fix #62 bug. The test will come in a future PR, already in the pipeline)