### PR TITLE
Build SimulationConfig in-memory instead of writing temp file

### DIFF
--- a/bluerecording/circuit.py
+++ b/bluerecording/circuit.py
@@ -8,15 +8,15 @@ the discretization info (node IDs, compartment structure, morphology access)
 import libsonata
 import numpy as np
 
-from .utils import get_circuit_path, resolve_simulation_config
+from .utils import resolve_simulation_config
 
 
 def init_circuit(path_to_config: str):
     """Initialize neurodamus and extract circuit discretization info.
 
-    Accepts either a simulation config or a circuit config. If a circuit
-    config is detected, a temporary simulation config is created
-    transparently.
+    Accepts either a simulation config or a circuit config path. Internally
+    builds a ``libsonata.SimulationConfig`` object in-memory (no temp files)
+    and passes it directly to neurodamus.
 
     Args:
         path_to_config: Path to a SONATA simulation or circuit configuration file.
@@ -36,9 +36,9 @@ def init_circuit(path_to_config: str):
     # in lightweight installs (e.g. CI with --quick).
     import neurodamus
 
-    with resolve_simulation_config(path_to_config) as path_to_simconfig:
+    with resolve_simulation_config(path_to_config) as sim_config_obj:
         nd = neurodamus.Neurodamus(
-            path_to_simconfig,
+            sim_config_obj,
             disable_reports=True,
             enable_coord_mapping=True,
             simulator="NEURON",
@@ -59,7 +59,7 @@ def init_circuit(path_to_config: str):
 
         population_name = node_manager.population_name
 
-        circuit_conf = libsonata.CircuitConfig.from_file(get_circuit_path(path_to_simconfig))
+        circuit_conf = libsonata.CircuitConfig.from_file(sim_config_obj.network)
         population = circuit_conf.node_population(population_name)
         morphologies_dir = circuit_conf.node_population_properties(population_name).morphologies_dir
 

--- a/bluerecording/utils.py
+++ b/bluerecording/utils.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import json
-import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -64,51 +63,28 @@ def _make_simulation_config(circuit_config_path: str | Path) -> dict:
 
 @contextmanager
 def resolve_simulation_config(path: str | Path):
-    """Context manager that yields a path to a simulation config.
+    """Context manager that yields a ``libsonata.SimulationConfig`` object.
 
-    If *path* already points to a simulation config, it is yielded as-is.
-    If *path* points to a circuit config, a temporary simulation config is
-    created (in the same directory, so relative paths inside the circuit
-    config keep working) and its path is yielded.  The temporary file is
-    removed on exit.
+    If *path* already points to a simulation config, the object is built from
+    that file.  If *path* points to a circuit config, a
+    ``SimulationConfig`` is constructed in-memory without writing any
+    temporary files (avoiding permission issues on read-only filesystems).
 
-    MPI-safe: only rank 0 creates and removes the temporary file.
-    A barrier ensures all ranks see the file before proceeding and
-    wait before it is deleted.
+    MPI-safe: only rank 0 reads the file and broadcasts the result.
 
     Args:
         path: Path to either a simulation or circuit configuration file.
 
     Yields:
-        Resolved path (str) to a simulation configuration file.
+        A ``libsonata.SimulationConfig`` instance.
     """
     path = Path(path).resolve()
     if not path.is_file():
         raise FileNotFoundError(f"Config file not found: {path}")
 
     if not _is_circuit_config(path):
-        yield str(path)
+        yield libsonata.SimulationConfig.from_file(str(path))
     else:
-        tmp_name = None
-        try:
-            if rank == 0:
-                sim_cfg = _make_simulation_config(path)
-                tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115
-                    mode="w",
-                    suffix=".json",
-                    prefix=".bluerecording_sim_",
-                    dir=path.parent,
-                    delete=False,
-                )
-                json.dump(sim_cfg, tmp, indent=2)
-                tmp.close()
-                tmp_name = tmp.name
-
-            tmp_name = comm.bcast(tmp_name, root=0)
-            comm.Barrier()
-
-            yield tmp_name
-        finally:
-            comm.Barrier()
-            if rank == 0 and tmp_name is not None:
-                Path(tmp_name).unlink(missing_ok=True)
+        sim_cfg_dict = _make_simulation_config(path)
+        sim_cfg_json = json.dumps(sim_cfg_dict)
+        yield libsonata.SimulationConfig(sim_cfg_json, str(path.parent))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "mpi4py",
     "h5py",
-    "neurodamus>=4.2.1",
+    "neurodamus>=4.2.2",
     "pandas",
     "morphio",
     "libsonata",


### PR DESCRIPTION
resolve_simulation_config now constructs a libsonata.SimulationConfig object directly from the circuit config JSON, avoiding temp file writes that fail on read-only filesystems (e.g. S3-backed mounts).