### PR TITLE
Publish to PyPI on GitHub Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,11 @@
 name: Publish to PyPI
 
-on: [pull_request, push, workflow_dispatch]
+on:
+  pull_request:
+  push:
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   wheel:
@@ -48,7 +53,7 @@ jobs:
         working-directory: dist
 
       - name: Publish to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: dist/


### PR DESCRIPTION
Switches the publish trigger from tag push to GitHub Release event, matching the cookiecutter-python-lib pattern. The wheel build still runs on every push/PR for validation, but the actual PyPI upload only happens when a GitHub Release is published.