### PR TITLE
Move electrodes_file from run section to LFP report blocks (1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 env:
-  NEURODAMUS_COMMIT: "4.2.1"
-  NEURODAMUS_NEOCORTEX_ROOT: ${{ github.workspace }}/neurodamus-models/build/install
+  NEURODAMUS_COMMIT: "4.2.3"
+  NEURODAMUS_NEOCORTEX_ROOT: ${{ github.workspace }}/install/neurodamus-neocortex
 
 jobs:
   lint:
@@ -63,22 +63,43 @@ jobs:
 
       - name: Build neurodamus-models
         run: |
-          git clone --depth=1 https://github.com/openbraininstitute/neurodamus-models.git
+          git clone --depth=1 https://github.com/openbraininstitute/neurodamus-models.git neurodamus-models-src
+          git clone --depth=1 --branch ${{ env.NEURODAMUS_COMMIT }} \
+              https://github.com/openbraininstitute/neurodamus.git neurodamus-src
+
           NEURODAMUS_PYTHON=$(python -c "import neurodamus; from pathlib import Path; print(Path(neurodamus.__file__).parent / 'data')")
-          cmake -B neurodamus-models/build -S neurodamus-models/ \
-              -DPython_EXECUTABLE=$(which python) \
-              -DCMAKE_INSTALL_PREFIX=${{ env.NEURODAMUS_NEOCORTEX_ROOT }} \
-              -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
-              -DNEURODAMUS_CORE_DIR=${NEURODAMUS_PYTHON} \
-              -DNEURODAMUS_MECHANISMS=neocortex \
-              -DNEURODAMUS_NCX_V5=ON \
-              -DNEURODAMUS_ENABLE_REPORTING=OFF
-          cmake --build neurodamus-models/build
-          cmake --install neurodamus-models/build
+
+          # neurodamus-models 3.0+ no longer uses CMake.
+          # Build: combine core mods + neurodamus-models mods + neocortex test mods → nrnivmodl
+          INSTALL_DIR=${{ env.NEURODAMUS_NEOCORTEX_ROOT }}
+          mkdir -p "$INSTALL_DIR/mod"
+          mkdir -p "$INSTALL_DIR/hoc"
+          mkdir -p "$INSTALL_DIR/lib"
+          mkdir -p "$INSTALL_DIR/bin"
+
+          # Copy core MOD files from neurodamus
+          cp ${NEURODAMUS_PYTHON}/mod/*.mod "$INSTALL_DIR/mod/"
+          # Copy neurodamus-models mechanism files
+          cp neurodamus-models-src/mod/*.mod "$INSTALL_DIR/mod/"
+          # Copy neocortex test mechanisms from neurodamus source
+          cp neurodamus-src/tests/mechanisms/neocortex/*.mod "$INSTALL_DIR/mod/"
+
+          # Copy HOC files
+          cp ${NEURODAMUS_PYTHON}/hoc/*.hoc "$INSTALL_DIR/hoc/"
+
+          # Build with nrnivmodl (no reporting needed for tests)
+          cd "$INSTALL_DIR"
+          nrnivmodl -coreneuron mod
+
+          # Install built libraries and binary
+          ARCH=$(uname -m)
+          cp "$ARCH/libnrnmech.so" "$INSTALL_DIR/lib/"
+          cp "$ARCH/libcorenrnmech.so" "$INSTALL_DIR/lib/" || true
+          cp "$ARCH/special" "$INSTALL_DIR/bin/"
 
       - name: Set test environment
         run: |
-          echo "HOC_LIBRARY_PATH=${{ env.NEURODAMUS_NEOCORTEX_ROOT }}/share/neurodamus_neocortex/hoc" >> $GITHUB_ENV
+          echo "HOC_LIBRARY_PATH=${{ env.NEURODAMUS_NEOCORTEX_ROOT }}/hoc" >> $GITHUB_ENV
           echo "CORENEURONLIB=${{ env.NEURODAMUS_NEOCORTEX_ROOT }}/lib/libcorenrnmech.so" >> $GITHUB_ENV
           echo "NRNMECH_LIB_PATH=${{ env.NEURODAMUS_NEOCORTEX_ROOT }}/lib/libnrnmech.so" >> $GITHUB_ENV
           echo "${{ env.NEURODAMUS_NEOCORTEX_ROOT }}/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,13 @@ jobs:
 
       - name: Build neurodamus-models
         run: |
-          git clone --depth=1 https://github.com/openbraininstitute/neurodamus-models.git neurodamus-models-src
           git clone --depth=1 https://github.com/openbraininstitute/neurodamus.git neurodamus-src
 
           NEURODAMUS_PYTHON=$(python -c "import neurodamus; from pathlib import Path; print(Path(neurodamus.__file__).parent / 'data')")
 
           # neurodamus-models 3.0+ no longer uses CMake.
-          # Build: combine core mods + neurodamus-models mods + neocortex test mods → nrnivmodl
+          # Build: combine core mods + neocortex test mods → nrnivmodl
+          # (following neurodamus's own CI: build-neocortex-models.sh)
           INSTALL_DIR=${{ env.NEURODAMUS_NEOCORTEX_ROOT }}
           mkdir -p "$INSTALL_DIR/mod"
           mkdir -p "$INSTALL_DIR/hoc"
@@ -78,8 +78,6 @@ jobs:
 
           # Copy core MOD files from neurodamus
           cp ${NEURODAMUS_PYTHON}/mod/*.mod "$INSTALL_DIR/mod/"
-          # Copy neurodamus-models mechanism files
-          cp neurodamus-models-src/mod/*.mod "$INSTALL_DIR/mod/"
           # Copy neocortex test mechanisms from neurodamus source
           cp neurodamus-src/tests/mechanisms/neocortex/*.mod "$INSTALL_DIR/mod/"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NEURODAMUS_COMMIT: "katta/lfp-electrode-offsets"
+  NEURODAMUS_COMMIT: "main"
   NEURODAMUS_NEOCORTEX_ROOT: ${{ github.workspace }}/install/neurodamus-neocortex
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,7 @@ jobs:
       - name: Build neurodamus-models
         run: |
           git clone --depth=1 https://github.com/openbraininstitute/neurodamus-models.git neurodamus-models-src
-          git clone --depth=1 --branch ${{ env.NEURODAMUS_COMMIT }} \
-              https://github.com/openbraininstitute/neurodamus.git neurodamus-src
+          git clone --depth=1 https://github.com/openbraininstitute/neurodamus.git neurodamus-src
 
           NEURODAMUS_PYTHON=$(python -c "import neurodamus; from pathlib import Path; print(Path(neurodamus.__file__).parent / 'data')")
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,13 @@ jobs:
           mkdir -p "$INSTALL_DIR/lib"
           mkdir -p "$INSTALL_DIR/bin"
 
-          # Copy core MOD files from neurodamus
-          cp ${NEURODAMUS_PYTHON}/mod/*.mod "$INSTALL_DIR/mod/"
+          # Copy core MOD files from neurodamus (exclude reporting mods that need libsonatareport)
+          for f in ${NEURODAMUS_PYTHON}/mod/*.mod; do
+            basename=$(basename "$f")
+            if [ "$basename" != "SonataReportHelper.mod" ] && [ "$basename" != "SonataReports.mod" ]; then
+              cp "$f" "$INSTALL_DIR/mod/"
+            fi
+          done
           # Copy neocortex test mechanisms from neurodamus source
           cp neurodamus-src/tests/mechanisms/neocortex/*.mod "$INSTALL_DIR/mod/"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,29 +69,22 @@ jobs:
 
           # neurodamus-models 3.0+ no longer uses CMake.
           # Build: combine core mods + neocortex test mods → nrnivmodl
-          # (following neurodamus's own CI: build-neocortex-models.sh)
           INSTALL_DIR=${{ env.NEURODAMUS_NEOCORTEX_ROOT }}
           mkdir -p "$INSTALL_DIR/mod"
           mkdir -p "$INSTALL_DIR/hoc"
           mkdir -p "$INSTALL_DIR/lib"
           mkdir -p "$INSTALL_DIR/bin"
 
-          # Copy core MOD files from neurodamus (exclude reporting mods that need libsonatareport)
-          for f in ${NEURODAMUS_PYTHON}/mod/*.mod; do
-            basename=$(basename "$f")
-            if [ "$basename" != "SonataReportHelper.mod" ] && [ "$basename" != "SonataReports.mod" ]; then
-              cp "$f" "$INSTALL_DIR/mod/"
-            fi
-          done
+          # Copy core MOD files from neurodamus
+          cp ${NEURODAMUS_PYTHON}/mod/*.mod "$INSTALL_DIR/mod/"
           # Copy neocortex test mechanisms from neurodamus source
           cp neurodamus-src/tests/mechanisms/neocortex/*.mod "$INSTALL_DIR/mod/"
-
           # Copy HOC files
           cp ${NEURODAMUS_PYTHON}/hoc/*.hoc "$INSTALL_DIR/hoc/"
 
-          # Build with nrnivmodl (no reporting needed for tests)
+          # Build with nrnivmodl (disable reporting lib, keep mods for neurodamus checks)
           cd "$INSTALL_DIR"
-          nrnivmodl -coreneuron mod
+          nrnivmodl -coreneuron -incflags "-DDISABLE_REPORTINGLIB" mod
 
           # Install built libraries and binary
           ARCH=$(uname -m)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NEURODAMUS_COMMIT: "4.2.3"
+  NEURODAMUS_COMMIT: "katta/lfp-electrode-offsets"
   NEURODAMUS_NEOCORTEX_ROOT: ${{ github.workspace }}/install/neurodamus-neocortex
 
 jobs:
@@ -63,7 +63,8 @@ jobs:
 
       - name: Build neurodamus-models
         run: |
-          git clone --depth=1 https://github.com/openbraininstitute/neurodamus.git neurodamus-src
+          git clone --depth=1 --branch ${{ env.NEURODAMUS_COMMIT }} \
+              https://github.com/openbraininstitute/neurodamus.git neurodamus-src
 
           NEURODAMUS_PYTHON=$(python -c "import neurodamus; from pathlib import Path; print(Path(neurodamus.__file__).parent / 'data')")
 

--- a/bluerecording/circuit.py
+++ b/bluerecording/circuit.py
@@ -48,10 +48,7 @@ def init_circuit(path_to_config: str):
             node_manager = next(iter(node_managers.values()))
         elif len(node_managers) > 1:
             # Multiple populations loaded — pick the one with cells on this rank
-            managers_with_cells = {
-                name: mgr for name, mgr in node_managers.items()
-                if len(mgr.get_final_gids()) > 0
-            }
+            managers_with_cells = {name: mgr for name, mgr in node_managers.items() if len(mgr.get_final_gids()) > 0}
             if len(managers_with_cells) != 1:
                 raise RuntimeError(
                     f"Expected exactly one population with cells, got: "

--- a/bluerecording/circuit.py
+++ b/bluerecording/circuit.py
@@ -43,8 +43,24 @@ def init_circuit(path_to_config: str):
             enable_coord_mapping=True,
             simulator="NEURON",
         )
-        assert len(nd.circuits.node_managers) == 1, "Multiple or no node managers are not allowed for the moment"
-        node_manager = next(iter(nd.circuits.node_managers.values()))
+        node_managers = nd.circuits.node_managers
+        if len(node_managers) == 1:
+            node_manager = next(iter(node_managers.values()))
+        elif len(node_managers) > 1:
+            # Multiple populations loaded — pick the one with cells on this rank
+            managers_with_cells = {
+                name: mgr for name, mgr in node_managers.items()
+                if len(mgr.get_final_gids()) > 0
+            }
+            if len(managers_with_cells) != 1:
+                raise RuntimeError(
+                    f"Expected exactly one population with cells, got: "
+                    f"{list(managers_with_cells.keys())}. "
+                    f"Use a node_set that targets a single population."
+                )
+            node_manager = next(iter(managers_with_cells.values()))
+        else:
+            raise RuntimeError("No node managers found.")
 
         ids = node_manager.get_final_gids()
         points = node_manager.target_manager.get_target(None).get_point_list(
@@ -62,5 +78,11 @@ def init_circuit(path_to_config: str):
         circuit_conf = libsonata.CircuitConfig.from_file(sim_config_obj.network)
         population = circuit_conf.node_population(population_name)
         morphologies_dir = circuit_conf.node_population_properties(population_name).morphologies_dir
+        alt_morphs = circuit_conf.node_population_properties(population_name).alternate_morphology_formats
+        if alt_morphs:
+            if "neurolucida-asc" in alt_morphs:
+                morphologies_dir = alt_morphs["neurolucida-asc"]
+            elif "h5v1" in alt_morphs:
+                morphologies_dir = alt_morphs["h5v1"]
 
     return node_manager, ids, cols, population, population_name, morphologies_dir

--- a/bluerecording/circuit.py
+++ b/bluerecording/circuit.py
@@ -74,12 +74,6 @@ def init_circuit(path_to_config: str):
 
         circuit_conf = libsonata.CircuitConfig.from_file(sim_config_obj.network)
         population = circuit_conf.node_population(population_name)
-        morphologies_dir = circuit_conf.node_population_properties(population_name).morphologies_dir
-        alt_morphs = circuit_conf.node_population_properties(population_name).alternate_morphology_formats
-        if alt_morphs:
-            if "neurolucida-asc" in alt_morphs:
-                morphologies_dir = alt_morphs["neurolucida-asc"]
-            elif "h5v1" in alt_morphs:
-                morphologies_dir = alt_morphs["h5v1"]
+        morphologies_dir = nd._sonata_circuits[population_name].MorphologyPath
 
     return node_manager, ids, cols, population, population_name, morphologies_dir

--- a/examples/SSCx/sscxSimulation/simulation_config.json
+++ b/examples/SSCx/sscxSimulation/simulation_config.json
@@ -4,8 +4,7 @@
     "dt": 0.025,
     "tstop": 5000,
     "random_seed": 851,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../electrodeFile/coeffs.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../electrodeFile/coeffs.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 5000.0,

--- a/examples/hippocampus/hippocampusSim/simulation_config_big.json
+++ b/examples/hippocampus/hippocampusSim/simulation_config_big.json
@@ -5,8 +5,7 @@
     "run": {
         "random_seed": 1234,
         "dt": 0.025,
-        "tstop": 20000.0,
-        "electrodes_file":"../electrodeFile/coeffs_big.h5"
+        "tstop": 20000.0
     },
     "conditions": {
         "extracellular_calcium": 1.0,
@@ -119,7 +118,7 @@
         "cells": "Mosaic",
         "sections": "all",
         "type": "lfp",
-        "variable_name": "v",
+      "electrodes_file": "../electrodeFile/coeffs_big.h5",
         "unit": "mV",
         "dt": 0.1,
         "start_time" : 0,

--- a/examples/hippocampus/hippocampusSim/simulation_config_small.json
+++ b/examples/hippocampus/hippocampusSim/simulation_config_small.json
@@ -5,8 +5,7 @@
     "run": {
         "random_seed": 1234,
         "dt": 0.025,
-        "tstop": 2.0,
-        "electrodes_file":"../electrodeFile/coeffs.h5"
+        "tstop": 2.0
     },
     "conditions": {
         "extracellular_calcium": 1.0,
@@ -119,7 +118,7 @@
         "cells": "LFPCompartments",
         "sections": "all",
         "type": "lfp",
-        "variable_name": "v",
+      "electrodes_file": "../electrodeFile/coeffs.h5",
         "unit": "V",
         "dt": 0.1,
         "start_time" : 0,

--- a/examples/single_cell_l5_tpc/simulation_config_distant.json
+++ b/examples/single_cell_l5_tpc/simulation_config_distant.json
@@ -4,8 +4,7 @@
     "tstop": 3000,
     "random_seed": 851,
     "run_mode":"WholeCell",
-    "integration_method":"crank_nicolson_ion",
-    "electrodes_file": "./reference/weights_distant_ref.h5"
+    "integration_method":"crank_nicolson_ion"
   },
   "target_simulator": "CORENEURON",
   "network": "./configuration/circuit_config.json",
@@ -45,9 +44,9 @@
   "reports": {
     "lfp_distant": {
       "type": "lfp",
+      "electrodes_file": "./reference/weights_distant_ref.h5",
       "cells": "Cell",
       "sections": "all",
-      "variable_name": "v",
       "dt": 0.1,
       "start_time": 0.0,
       "end_time": 5000.0

--- a/examples/single_cell_l5_tpc/simulation_config_near.json
+++ b/examples/single_cell_l5_tpc/simulation_config_near.json
@@ -4,8 +4,7 @@
     "tstop": 3000,
     "random_seed": 851,
     "run_mode":"WholeCell",
-    "integration_method":"crank_nicolson_ion",
-    "electrodes_file": "./reference/weights_near_ref.h5"
+    "integration_method":"crank_nicolson_ion"
   },
   "target_simulator": "CORENEURON",
   "network": "./configuration/circuit_config.json",
@@ -45,9 +44,9 @@
   "reports": {
     "lfp_near": {
       "type": "lfp",
+      "electrodes_file": "./reference/weights_near_ref.h5",
       "cells": "Cell",
       "sections": "all",
-      "variable_name": "v",
       "dt": 0.1,
       "start_time": 0.0,
       "end_time": 5000.0

--- a/examples/sscx_100_cells/simulation_config.json
+++ b/examples/sscx_100_cells/simulation_config.json
@@ -3,8 +3,7 @@
   "run": {
     "dt": 0.025,
     "random_seed": 1,
-    "tstop": 100,
-    "electrodes_file": "./reference/weights_ref.h5"
+    "tstop": 100
   },
   "network": "./configuration/circuit_config.json",
   "node_sets_file": "user_node_sets.json",
@@ -31,9 +30,9 @@
   "reports": {
     "extracellular_report": {
       "type": "lfp",
+      "electrodes_file": "./reference/weights_ref.h5",
       "cells": "All",
       "sections": "all",
-      "variable_name": "v",
       "dt": 0.1,
       "start_time": 0.0,
       "end_time": 5000.0

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/0/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/0/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 843,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/1/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/1/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 814,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/2/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/2/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 632,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/3/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/3/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 508,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/4/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/4/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 268,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/5/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/5/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 40,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/6/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/6/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 16,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/7/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/7/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 306,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/8/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/8/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 175,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/disconnected/9/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/disconnected/9/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 75,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -162,8 +161,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 3000.0,

--- a/examples/whiskerFlick/whiskerFlickSim/original/0/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/0/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 2200,
     "random_seed": 843,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/examples/whiskerFlick/whiskerFlickSim/original/1/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/1/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 814,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/examples/whiskerFlick/whiskerFlickSim/original/2/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/2/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 632,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/examples/whiskerFlick/whiskerFlickSim/original/3/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/3/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 508,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/examples/whiskerFlick/whiskerFlickSim/original/4/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/4/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 268,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/examples/whiskerFlick/whiskerFlickSim/original/5/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/5/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 40,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/examples/whiskerFlick/whiskerFlickSim/original/6/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/6/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 16,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/examples/whiskerFlick/whiskerFlickSim/original/7/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/7/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 306,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/examples/whiskerFlick/whiskerFlickSim/original/8/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/8/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 175,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/examples/whiskerFlick/whiskerFlickSim/original/9/simulation_config.json
+++ b/examples/whiskerFlick/whiskerFlickSim/original/9/simulation_config.json
@@ -3,8 +3,7 @@
     "dt": 0.025,
     "tstop": 12000,
     "random_seed": 75,
-    "run_mode":"WholeCell",
-    "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5"
+    "run_mode":"WholeCell"
   },
 
   "conditions": {
@@ -169,8 +168,8 @@
 
       "lfp_report": {
         "type": "lfp",
+      "electrodes_file": "../../../electrodeFile/coeffs_eeg.h5",
         "cells": "Mosaic",
-        "variable_name": "v",
         "dt": 0.1,
         "start_time": 0.0,
         "end_time": 12000,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "neurodamus>=4.2.2",
     "pandas",
     "morphio",
-    "libsonata",
+    "libsonata>=0.1.37",
     "voxcell",
     "scikit-learn",
 ]


### PR DESCRIPTION
Adapt all example simulation configs to the updated libsonata API:
- Remove electrodes_file from the run section
- Add electrodes_file to each LFP report block
- Remove variable_name from LFP reports (no longer allowed)

Fix: https://github.com/openbraininstitute/BlueRecording/issues/64

Required here: https://github.com/openbraininstitute/prod-circuit-simulation/issues/122