### PR TITLE
Skip connectivity loading during circuit init

### DIFF
--- a/bluerecording/circuit.py
+++ b/bluerecording/circuit.py
@@ -44,6 +44,7 @@ def init_circuit(path_to_config: str):
             sim_config_obj,
             disable_reports=True,
             enable_coord_mapping=True,
+            restrict_connectivity=2,
             simulator="NEURON",
         )
         node_managers = nd.circuits.node_managers


### PR DESCRIPTION
Skip all connectivity loading during circuit initialization by passing `restrict_connectivity=2` to neurodamus.

BlueRecording only needs cell morphologies and compartment structure, not synaptic connections. This reduces initialization time and memory usage for large circuits.

Suggested in: https://github.com/openbraininstitute/prod-circuit-simulation/issues/227#issuecomment-5003416437

Fix: #106